### PR TITLE
Add Apple-style unit conversion site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# site
+# Convertisseur Universel
+
+Un site de conversion de mesures avec une esthétique minimaliste inspirée d'Apple.
+
+## Démarrage
+
+Ouvrez `index.html` dans votre navigateur préféré pour utiliser le convertisseur.
+
+Actuellement, les conversions suivantes sont disponibles :
+
+- **Longueur** : mètres, kilomètres, miles, pieds
+- **Poids** : kilogrammes, grammes, livres
+- **Température** : Celsius, Fahrenheit, Kelvin
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <h1>Convertisseur Universel</h1>
+    </header>
+    <main>
+        <div class="converter">
+            <div class="row">
+                <label for="category">Catégorie</label>
+                <select id="category">
+                    <option value="length">Longueur</option>
+                    <option value="weight">Poids</option>
+                    <option value="temperature">Température</option>
+                </select>
+            </div>
+            <div class="row">
+                <label for="from-value">Valeur</label>
+                <input type="number" id="from-value" value="0" />
+            </div>
+            <div class="row">
+                <label for="from-unit">De</label>
+                <select id="from-unit"></select>
+            </div>
+            <div class="row">
+                <label for="to-unit">À</label>
+                <select id="to-unit"></select>
+            </div>
+            <div class="row result">
+                <span id="result">0</span>
+            </div>
+        </div>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,108 @@
+const categories = {
+    length: {
+        units: {
+            m: { name: 'Mètre', factor: 1 },
+            km: { name: 'Kilomètre', factor: 1000 },
+            mi: { name: 'Mile', factor: 1609.34 },
+            ft: { name: 'Pied', factor: 0.3048 }
+        }
+    },
+    weight: {
+        units: {
+            kg: { name: 'Kilogramme', factor: 1 },
+            g: { name: 'Gramme', factor: 0.001 },
+            lb: { name: 'Livre', factor: 0.453592 }
+        }
+    },
+    temperature: {
+        units: {
+            c: { name: 'Celsius' },
+            f: { name: 'Fahrenheit' },
+            k: { name: 'Kelvin' }
+        }
+    }
+};
+
+const categorySelect = document.getElementById('category');
+const fromValue = document.getElementById('from-value');
+const fromUnit = document.getElementById('from-unit');
+const toUnit = document.getElementById('to-unit');
+const resultSpan = document.getElementById('result');
+
+function populateUnits(cat) {
+    const units = categories[cat].units;
+    fromUnit.innerHTML = '';
+    toUnit.innerHTML = '';
+    for (const key in units) {
+        const optionFrom = document.createElement('option');
+        optionFrom.value = key;
+        optionFrom.textContent = units[key].name;
+        fromUnit.appendChild(optionFrom);
+
+        const optionTo = document.createElement('option');
+        optionTo.value = key;
+        optionTo.textContent = units[key].name;
+        toUnit.appendChild(optionTo);
+    }
+    toUnit.selectedIndex = 1;
+}
+
+function convert() {
+    const cat = categorySelect.value;
+    const value = parseFloat(fromValue.value);
+    const from = fromUnit.value;
+    const to = toUnit.value;
+
+    if (isNaN(value)) {
+        resultSpan.textContent = '—';
+        return;
+    }
+
+    let result = 0;
+
+    if (cat === 'temperature') {
+        result = convertTemperature(value, from, to);
+    } else {
+        const base = value * categories[cat].units[from].factor;
+        result = base / categories[cat].units[to].factor;
+    }
+
+    resultSpan.textContent = result.toFixed(4);
+}
+
+function convertTemperature(value, from, to) {
+    let celsius;
+    switch (from) {
+        case 'c':
+            celsius = value;
+            break;
+        case 'f':
+            celsius = (value - 32) * 5 / 9;
+            break;
+        case 'k':
+            celsius = value - 273.15;
+            break;
+    }
+
+    switch (to) {
+        case 'c':
+            return celsius;
+        case 'f':
+            return celsius * 9 / 5 + 32;
+        case 'k':
+            return celsius + 273.15;
+    }
+}
+
+categorySelect.addEventListener('change', () => {
+    populateUnits(categorySelect.value);
+    convert();
+});
+
+fromValue.addEventListener('input', convert);
+fromUnit.addEventListener('change', convert);
+toUnit.addEventListener('change', convert);
+
+// Initialize
+populateUnits(categorySelect.value);
+convert();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,60 @@
+body {
+    margin: 0;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    background: linear-gradient(#f5f5f7, #ffffff);
+    color: #1d1d1f;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+header {
+    padding: 2rem 0;
+    text-align: center;
+}
+
+h1 {
+    font-weight: 600;
+    margin: 0;
+}
+
+main {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.converter {
+    background: #ffffff;
+    padding: 2rem;
+    border-radius: 1rem;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+    max-width: 400px;
+    width: 100%;
+}
+
+.row {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1rem;
+}
+
+.row label {
+    margin-bottom: 0.5rem;
+}
+
+.row input,
+.row select {
+    padding: 0.5rem;
+    border: 1px solid #d2d2d7;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+}
+
+.result {
+    text-align: center;
+    font-size: 2rem;
+    font-weight: 600;
+    margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- Build static HTML interface for converting length, weight, and temperature units
- Apply Apple-inspired minimal styling
- Document available conversions and usage in README

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16b84b73c832997294d5a4263a724