### PR TITLE
feat: expand unit conversion categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,25 @@ Un site de conversion de mesures avec une esthétique minimaliste inspirée d'Ap
 
 Ouvrez `index.html` dans votre navigateur préféré pour utiliser le convertisseur.
 
-Actuellement, les conversions suivantes sont disponibles :
+Les conversions suivantes sont disponibles :
 
-- **Longueur** : mètres, kilomètres, miles, pieds
-- **Poids** : kilogrammes, grammes, livres
+- **Longueur** : mètres, centimètres, millimètres, kilomètres, pouces, pieds, miles
+- **Masse** : kilogrammes, grammes, tonnes, livres, onces
+- **Aire** : mètres carrés, centimètres carrés, hectares, acres
+- **Volume** : litres, mètres cubes, gallons (US)
+- **Temps** : secondes, minutes, heures
+- **Fréquence** : hertz, tours/minute, radians/seconde
+- **Vitesse** : m/s, km/h, mph
+- **Accélération** : m/s², g
+- **Force** : newtons, livres-force, kilogrammes-force
+- **Pression** : pascals, bar, atmosphères, psi
+- **Énergie** : joules, kilojoules, mégajoules, watt-heures, kilowatt-heures, calories (th), BTU (IT)
+- **Puissance** : watts, kilowatts, chevaux vapeur
+- **Densité** : kg/m³, g/cm³
+- **Débit** : m³/s, L/min, L/s, m³/h
+- **Couple** : N·m, lbf·ft
+- **Angle** : radians, degrés
+- **Données** : bits, octets, kB, MB, GB, KiB, MiB, GiB
 - **Température** : Celsius, Fahrenheit, Kelvin
 
 

--- a/index.html
+++ b/index.html
@@ -16,8 +16,23 @@
                 <label for="category">Catégorie</label>
                 <select id="category">
                     <option value="length">Longueur</option>
-                    <option value="weight">Poids</option>
+                    <option value="weight">Masse</option>
                     <option value="temperature">Température</option>
+                    <option value="area">Aire</option>
+                    <option value="volume">Volume</option>
+                    <option value="time">Temps</option>
+                    <option value="frequency">Fréquence</option>
+                    <option value="speed">Vitesse</option>
+                    <option value="acceleration">Accélération</option>
+                    <option value="force">Force</option>
+                    <option value="pressure">Pression</option>
+                    <option value="energy">Énergie</option>
+                    <option value="power">Puissance</option>
+                    <option value="density">Densité</option>
+                    <option value="flow">Débit</option>
+                    <option value="torque">Couple</option>
+                    <option value="angle">Angle</option>
+                    <option value="data">Données</option>
                 </select>
             </div>
             <div class="row">

--- a/script.js
+++ b/script.js
@@ -2,16 +2,134 @@ const categories = {
     length: {
         units: {
             m: { name: 'Mètre', factor: 1 },
+            cm: { name: 'Centimètre', factor: 0.01 },
+            mm: { name: 'Millimètre', factor: 0.001 },
             km: { name: 'Kilomètre', factor: 1000 },
-            mi: { name: 'Mile', factor: 1609.34 },
-            ft: { name: 'Pied', factor: 0.3048 }
+            in: { name: 'Pouce', factor: 0.0254 },
+            ft: { name: 'Pied', factor: 0.3048 },
+            mi: { name: 'Mile', factor: 1609.34 }
         }
     },
     weight: {
         units: {
             kg: { name: 'Kilogramme', factor: 1 },
             g: { name: 'Gramme', factor: 0.001 },
-            lb: { name: 'Livre', factor: 0.453592 }
+            t: { name: 'Tonne', factor: 1000 },
+            lb: { name: 'Livre', factor: 0.45359237 },
+            oz: { name: 'Once', factor: 0.028349523125 }
+        }
+    },
+    area: {
+        units: {
+            m2: { name: 'Mètre carré', factor: 1 },
+            cm2: { name: 'Centimètre carré', factor: 0.0001 },
+            ha: { name: 'Hectare', factor: 10000 },
+            acre: { name: 'Acre', factor: 4046.8564224 }
+        }
+    },
+    volume: {
+        units: {
+            L: { name: 'Litre', factor: 1 },
+            m3: { name: 'Mètre cube', factor: 1000 },
+            gal: { name: 'Gallon (US)', factor: 3.785411784 }
+        }
+    },
+    time: {
+        units: {
+            s: { name: 'Seconde', factor: 1 },
+            min: { name: 'Minute', factor: 60 },
+            h: { name: 'Heure', factor: 3600 }
+        }
+    },
+    frequency: {
+        units: {
+            Hz: { name: 'Hertz', factor: 1 },
+            rpm: { name: 'Tours/minute', factor: 1 / 60 },
+            rad_s: { name: 'Rad/s', factor: 1 / (2 * Math.PI) }
+        }
+    },
+    speed: {
+        units: {
+            m_s: { name: 'm/s', factor: 1 },
+            km_h: { name: 'km/h', factor: 1000 / 3600 },
+            mph: { name: 'mph', factor: 1609.344 / 3600 }
+        }
+    },
+    acceleration: {
+        units: {
+            m_s2: { name: 'm/s²', factor: 1 },
+            g: { name: 'g', factor: 9.80665 }
+        }
+    },
+    force: {
+        units: {
+            N: { name: 'Newton', factor: 1 },
+            lbf: { name: 'Livre-force', factor: 4.4482216152605 },
+            kgf: { name: 'Kilogramme-force', factor: 9.80665 }
+        }
+    },
+    pressure: {
+        units: {
+            Pa: { name: 'Pascal', factor: 1 },
+            bar: { name: 'Bar', factor: 100000 },
+            atm: { name: 'Atmosphère', factor: 101325 },
+            psi: { name: 'Psi', factor: 6894.757293168 }
+        }
+    },
+    energy: {
+        units: {
+            J: { name: 'Joule', factor: 1 },
+            kJ: { name: 'Kilojoule', factor: 1000 },
+            MJ: { name: 'Mégajoule', factor: 1000000 },
+            Wh: { name: 'Watt-heure', factor: 3600 },
+            kWh: { name: 'Kilowatt-heure', factor: 3600000 },
+            cal: { name: 'Calorie (th)', factor: 4.184 },
+            BTU: { name: 'BTU (IT)', factor: 1055.056 }
+        }
+    },
+    power: {
+        units: {
+            W: { name: 'Watt', factor: 1 },
+            kW: { name: 'Kilowatt', factor: 1000 },
+            hp: { name: 'Cheval vapeur', factor: 745.699872 }
+        }
+    },
+    density: {
+        units: {
+            kg_m3: { name: 'kg/m³', factor: 1 },
+            g_cm3: { name: 'g/cm³', factor: 1000 }
+        }
+    },
+    flow: {
+        units: {
+            m3_s: { name: 'm³/s', factor: 1 },
+            L_min: { name: 'L/min', factor: 1 / 60000 },
+            L_s: { name: 'L/s', factor: 0.001 },
+            m3_h: { name: 'm³/h', factor: 1 / 3600 }
+        }
+    },
+    torque: {
+        units: {
+            Nm: { name: 'N·m', factor: 1 },
+            lbf_ft: { name: 'lbf·ft', factor: 1.3558179483314004 }
+        }
+    },
+    angle: {
+        units: {
+            rad: { name: 'Radian', factor: 1 },
+            deg: { name: 'Degré', factor: Math.PI / 180 }
+        }
+    },
+    data: {
+        units: {
+            byte: { name: 'Octet', factor: 1 },
+            bit: { name: 'Bit', factor: 1 / 8 },
+            kB: { name: 'Kilooctet', factor: 1000 },
+            MB: { name: 'Mégaoctet', factor: 1000000 },
+            GB: { name: 'Gigaoctet', factor: 1000000000 },
+            KiB: { name: 'Kibioctet', factor: 1024 },
+            MiB: { name: 'Mibioctet', factor: 1024 ** 2 },
+            GiB: { name: 'Gibioctet', factor: 1024 ** 3 }
         }
     },
     temperature: {


### PR DESCRIPTION
## Summary
- extend conversion engine with many new categories including area, volume, time, frequency, speed, acceleration, force, pressure, energy, power, density, flow, torque, angle, and data
- expose new categories in the UI for quick selection
- document all supported conversions in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c16ec15d3c8329bded9d2a0eac1361