### PR TITLE
Reset unit selects when changing category

### DIFF
--- a/script.js
+++ b/script.js
@@ -162,7 +162,9 @@ function populateUnits(cat) {
         optionTo.textContent = units[key].name;
         toUnit.appendChild(optionTo);
     }
-    toUnit.selectedIndex = 1;
+    // reset selections to avoid keeping units from previous categories
+    fromUnit.selectedIndex = 0;
+    toUnit.selectedIndex = Math.min(1, toUnit.options.length - 1);
 }
 
 function convert() {


### PR DESCRIPTION
## Summary
- Reset unit selectors when switching categories to avoid stale units

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c170582eac8329b8a6c9bbb0ec72bf