### PR TITLE
Add legal and sitemap pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,14 @@ Les conversions suivantes sont disponibles :
 ## Visualisation en ligne
 
 Visualisez le site directement sur StackBlitz : https://stackblitz.com/github/tokojimo/site
+
+## Pages d'information
+
+- [À propos](a-propos.html)
+- [Contact](contact.html)
+- [Politique de confidentialité](politique-de-confidentialite.html)
+- [Conditions générales](conditions-generales.html)
+- [Cookies](cookies.html)
+- [Accessibilité](accessibilite.html)
+- [Sécurité des données](securite-des-donnees.html)
+- [Plan du site](sitemap.html)

--- a/a-propos.html
+++ b/a-propos.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>À propos - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>À propos</h1>
+        <p>Ce site fournit des outils de conversion pour de nombreuses unités afin de faciliter les calculs du quotidien.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/accessibilite.html
+++ b/accessibilite.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accessibilité - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Accessibilité</h1>
+        <p>Nous travaillons à rendre ce site accessible à tous les utilisateurs, quelle que soit leur situation.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/conditions-generales.html
+++ b/conditions-generales.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Conditions générales - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Conditions générales</h1>
+        <p>L'utilisation de ce site implique l'acceptation des présentes conditions générales d'utilisation.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Contact</h1>
+        <p>Pour toute question, écrivez-nous à <a href="mailto:info@example.com">info@example.com</a>.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/cookies.html
+++ b/cookies.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cookies - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Cookies</h1>
+        <p>Vous pouvez ajuster vos préférences de cookies et en savoir plus sur leur utilisation sur ce site.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -8,9 +8,10 @@
 </head>
 <body>
     <header>
-        <h1>Convertisseur Universel</h1>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
     </header>
     <main>
+        <h1>Convertisseur Universel</h1>
         <div class="converter">
             <div class="row">
                 <label for="category">Catégorie</label>
@@ -52,6 +53,18 @@
             </div>
         </div>
     </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
     <script src="script.js"></script>
 </body>
 </html>

--- a/politique-de-confidentialite.html
+++ b/politique-de-confidentialite.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Politique de confidentialité - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Politique de confidentialité</h1>
+        <p>Nous ne collectons que les données nécessaires au fonctionnement du site et respectons votre vie privée.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: /sitemap.xml

--- a/securite-des-donnees.html
+++ b/securite-des-donnees.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sécurité des données - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Sécurité des données</h1>
+        <p>Nous utilisons des pratiques de sécurité standards pour protéger les informations et les journaux de navigation.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/sitemap.html
+++ b/sitemap.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plan du site - Convertisseur Universel</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Plan du site</h1>
+        <ul>
+            <li><a href="index.html">Accueil</a></li>
+            <li><a href="a-propos.html">À propos</a></li>
+            <li><a href="contact.html">Contact</a></li>
+            <li><a href="politique-de-confidentialite.html">Politique de confidentialité</a></li>
+            <li><a href="conditions-generales.html">Conditions générales</a></li>
+            <li><a href="cookies.html">Cookies</a></li>
+            <li><a href="accessibilite.html">Accessibilité</a></li>
+            <li><a href="securite-des-donnees.html">Sécurité des données</a></li>
+        </ul>
+    </main>
+    <footer>
+        <nav>
+            <a href="a-propos.html">À propos</a>
+            <a href="contact.html">Contact</a>
+            <a href="politique-de-confidentialite.html">Confidentialité</a>
+            <a href="conditions-generales.html">Conditions</a>
+            <a href="cookies.html">Cookies</a>
+            <a href="accessibilite.html">Accessibilité</a>
+            <a href="securite-des-donnees.html">Sécurité des données</a>
+            <a href="sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>/index.html</loc></url>
+  <url><loc>/a-propos.html</loc></url>
+  <url><loc>/contact.html</loc></url>
+  <url><loc>/politique-de-confidentialite.html</loc></url>
+  <url><loc>/conditions-generales.html</loc></url>
+  <url><loc>/cookies.html</loc></url>
+  <url><loc>/accessibilite.html</loc></url>
+  <url><loc>/securite-des-donnees.html</loc></url>
+  <url><loc>/sitemap.html</loc></url>
+</urlset>

--- a/style.css
+++ b/style.css
@@ -58,3 +58,25 @@ main {
     font-weight: 600;
     margin-top: 1rem;
 }
+.site-title {
+    margin: 0;
+    font-weight: 600;
+    text-align: center;
+}
+
+.site-title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+footer {
+    background: #f5f5f7;
+    padding: 1rem;
+    text-align: center;
+}
+
+footer nav a {
+    margin: 0 0.5rem;
+    color: inherit;
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- add legal information pages (about, contact, privacy, terms, cookies, accessibility, security)
- introduce sitemap files and footer navigation links
- update styles to support footer and site title

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/site/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c171f25c008329ac8a00105a57d248