### PR TITLE
fix: remove incorrect Arabic alternate links

### DIFF
--- a/en/length/convert-meter-to-foot/index.html
+++ b/en/length/convert-meter-to-foot/index.html
@@ -9,7 +9,6 @@
   <link rel="alternate" hreflang="fr-FR" href="/fr/longueur/convertir-metre-en-pied/" />
   <link rel="alternate" hreflang="en-US" href="/en/length/convert-meter-to-foot/" />
   <link rel="alternate" hreflang="hi-IN" href="/hi/lambai/mitar-se-phut-badalna/" />
-  <link rel="alternate" hreflang="ar-AE" href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/" />
   <meta property="og:title" content="Convert meter to foot | MesureConvert" />
   <meta property="og:description" content="Convert meters to feet with MesureConvert, a clear and reliable tool. Instant calculations for home projects, studies, or travel planning." />
   <meta property="og:url" content="/en/length/convert-meter-to-foot/" />

--- a/fr/longueur/convertir-metre-en-pied/index.html
+++ b/fr/longueur/convertir-metre-en-pied/index.html
@@ -9,7 +9,6 @@
   <link rel="alternate" hreflang="fr-FR" href="/fr/longueur/convertir-metre-en-pied/" />
   <link rel="alternate" hreflang="en-US" href="/en/length/convert-meter-to-foot/" />
   <link rel="alternate" hreflang="hi-IN" href="/hi/lambai/mitar-se-phut-badalna/" />
-  <link rel="alternate" hreflang="ar-AE" href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/" />
   <meta property="og:title" content="Convertir mètre en pied | MesureConvert" />
   <meta property="og:description" content="Transformez vos mesures de mètre en pied grâce à l’outil MesureConvert, simple et fiable. Calculs instantanés pour projets maison, études ou voyages pratiques." />
   <meta property="og:url" content="/fr/longueur/convertir-metre-en-pied/" />

--- a/hi/lambai/mitar-se-phut-badalna/index.html
+++ b/hi/lambai/mitar-se-phut-badalna/index.html
@@ -9,7 +9,6 @@
   <link rel="alternate" hreflang="fr-FR" href="/fr/longueur/convertir-metre-en-pied/" />
   <link rel="alternate" hreflang="en-US" href="/en/length/convert-meter-to-foot/" />
   <link rel="alternate" hreflang="hi-IN" href="/hi/lambai/mitar-se-phut-badalna/" />
-  <link rel="alternate" hreflang="ar-AE" href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/" />
   <meta property="og:title" content="मीटर को फ़ुट में बदलें | MesureConvert" />
   <meta property="og:description" content="MesureConvert से मीटर को फ़ुट में तुरंत बदलें। यह सरल उपकरण घर, पढ़ाई या यात्रा की योजनाओं के लिए उपयोगी है।" />
   <meta property="og:url" content="/hi/lambai/mitar-se-phut-badalna/" />


### PR DESCRIPTION
## Summary
- remove incorrect `ar-AE` alternate links from meter-to-foot conversion pages in French, English, and Hindi

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1791b1d548329bb793ae4c0f387ff