### PR TITLE
Use Math.pow for binary unit factors

### DIFF
--- a/script.js
+++ b/script.js
@@ -128,8 +128,8 @@ const categories = {
             MB: { name: 'Mégaoctet', factor: 1000000 },
             GB: { name: 'Gigaoctet', factor: 1000000000 },
             KiB: { name: 'Kibioctet', factor: 1024 },
-            MiB: { name: 'Mibioctet', factor: 1024 ** 2 },
-            GiB: { name: 'Gibioctet', factor: 1024 ** 3 }
+            MiB: { name: 'Mibioctet', factor: Math.pow(1024, 2) },
+            GiB: { name: 'Gibioctet', factor: Math.pow(1024, 3) }
         }
     },
     temperature: {


### PR DESCRIPTION
## Summary
- Use `Math.pow` for MiB and GiB factors to ensure compatibility with older browsers

## Testing
- `node - <<'NODE'
const dataUnits = {
  byte: { factor: 1 },
  bit: { factor: 1 / 8 },
  kB: { factor: 1000 },
  MB: { factor: 1000000 },
  GB: { factor: 1000000000 },
  KiB: { factor: 1024 },
  MiB: { factor: Math.pow(1024, 2) },
  GiB: { factor: Math.pow(1024, 3) },
};

function convert(value, from, to) {
  const base = value * dataUnits[from].factor;
  return base / dataUnits[to].factor;
}

console.log('1 MiB -> KiB:', convert(1, 'MiB', 'KiB'));
console.log('1 GiB -> MiB:', convert(1, 'GiB', 'MiB'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68c1791ddfd883298824a37536074300