### PR TITLE
Add converter hub page and enhance homepage

### DIFF
--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Tous les convertisseurs d’unités | MesureConvert</title>
+  <meta name="description" content="Accédez aux convertisseurs par catégorie. Longueur, masse, température, etc." />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="MesureConvert" />
+  <meta property="og:title" content="Tous les convertisseurs d’unités | MesureConvert" />
+  <meta property="og:description" content="Accédez aux convertisseurs par catégorie. Longueur, masse, température, etc." />
+  <meta property="og:url" content="/convertisseurs/" />
+  <link rel="stylesheet" href="/style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/index.html"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <h1>Tous les convertisseurs par catégorie</h1>
+    <p>Choisissez une catégorie pour afficher ses conversions.</p>
+    <div class="content">
+      <ul class="categories">
+        <li>Longueur – mesures de m à ft, km, mi…</li>
+        <li>Masse – de g à kg, lb, oz…</li>
+        <li>Température – entre °C, °F, K…</li>
+        <li>Volume – litres, gallons, m³…</li>
+        <li>Aire – m², ft², hectares…</li>
+        <li>Vitesse – km/h, mph, m/s…</li>
+        <li>Temps – s, min, h…</li>
+        <li>Énergie – J, kWh, cal…</li>
+        <li>Pression – Pa, bar, psi…</li>
+        <li>Données – Mo, Go, To…</li>
+      </ul>
+    </div>
+    <aside class="sidebar">
+      <div class="ad">Publicité 300×250</div>
+    </aside>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,13 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Convertisseur Universel</title>
+    <title>Convertisseurs d’unités précis et rapides | MesureConvert</title>
+    <meta name="description" content="Convertissez longueur, masse, température, volume, vitesse, données et plus. Résultats fiables, formules et exemples." />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="MesureConvert" />
+    <meta property="og:title" content="Convertisseurs d’unités précis et rapides | MesureConvert" />
+    <meta property="og:description" content="Convertissez longueur, masse, température, volume, vitesse, données et plus. Résultats fiables, formules et exemples." />
+    <meta property="og:url" content="/" />
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -11,7 +17,8 @@
         <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
     </header>
     <main>
-        <h1>Convertisseur Universel</h1>
+        <h1>Convertisseurs d’unités fiables, instantanés.</h1>
+        <p>Entrez une valeur, choisissez vos unités, obtenez le résultat et la formule. Sans inscription.</p>
         <div class="converter">
             <div class="row">
                 <label for="category">Catégorie</label>
@@ -52,6 +59,52 @@
                 <span id="result">0</span>
             </div>
         </div>
+        <p><a class="cta" href="convertisseurs/index.html">Ouvrir le convertisseur</a></p>
+        <section>
+            <h2>Convertisseurs par catégorie</h2>
+            <ul class="categories">
+                <li>Longueur – Conversions entre m, ft, km, mi, cm, in…</li>
+                <li>Masse – Conversions entre kg, lb, g, oz…</li>
+                <li>Température – Conversions entre °C, °F, K…</li>
+                <li>Volume – Conversions entre L, gal, m³…</li>
+                <li>Aire – Conversions entre m², ft²…</li>
+                <li>Vitesse – Conversions entre km/h, mph…</li>
+                <li>Temps – Conversions entre s, min, h…</li>
+                <li>Énergie – Conversions entre J, kWh…</li>
+                <li>Pression – Conversions entre Pa, bar…</li>
+                <li>Données – Conversions entre Mo, Go…</li>
+            </ul>
+        </section>
+        <section>
+            <h2>Conversions les plus demandées</h2>
+            <ul class="popular">
+                <li><a href="fr/longueur/convertir-metre-en-pied/">m→ft</a></li>
+                <li>cm→in</li>
+                <li>kg→lb</li>
+                <li>°C→°F</li>
+                <li>L→gal</li>
+                <li>km/h→mph</li>
+                <li>s→min</li>
+                <li>J→kWh</li>
+                <li>Pa→bar</li>
+                <li>Mo→Go</li>
+            </ul>
+        </section>
+        <section>
+            <h2>Méthode et fiabilité</h2>
+            <p>Formules sourcées (SI, BIPM, NIST). Arrondis expliqués. Accessibilité et respect des données.</p>
+        </section>
+        <section>
+            <h2>Questions fréquentes</h2>
+            <dl>
+                <dt>Les conversions sont-elles exactes ?</dt>
+                <dd>Oui, basées sur définitions officielles; l’arrondi est configurable.</dd>
+                <dt>Puis-je changer la virgule/point ?</dt>
+                <dd>Oui dans les préférences.</dd>
+                <dt>Puis-je exporter ?</dt>
+                <dd>Oui en copie, CSV, lien partageable.</dd>
+            </dl>
+        </section>
     </main>
     <footer>
         <nav>

--- a/sitemap.html
+++ b/sitemap.html
@@ -14,6 +14,7 @@
         <h1>Plan du site</h1>
         <ul>
             <li><a href="index.html">Accueil</a></li>
+            <li><a href="convertisseurs/index.html">Convertisseurs</a></li>
             <li><a href="a-propos.html">À propos</a></li>
             <li><a href="contact.html">Contact</a></li>
             <li><a href="politique-de-confidentialite.html">Politique de confidentialité</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>/index.html</loc></url>
+  <url><loc>/convertisseurs/</loc></url>
   <url><loc>/a-propos.html</loc></url>
   <url><loc>/contact.html</loc></url>
   <url><loc>/politique-de-confidentialite.html</loc></url>

--- a/style.css
+++ b/style.css
@@ -80,3 +80,24 @@ footer nav a {
     color: inherit;
     text-decoration: none;
 }
+
+.cta {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.75rem 1.25rem;
+    background: #007acc;
+    color: #fff;
+    text-decoration: none;
+    border-radius: 0.5rem;
+}
+
+.categories,
+.popular {
+    list-style: none;
+    padding: 0;
+}
+
+.categories li,
+.popular li {
+    margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add dedicated hub at `/convertisseurs/` listing categories
- update homepage with SEO metadata, introductory content, and CTA
- include converter hub in HTML/XML sitemaps and basic styles for new elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1829158c083298235c7483212df20