### PR TITLE
Add index pages for length and temperature categories

### DIFF
--- a/ar/alhararah/index.html
+++ b/ar/alhararah/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <title>تحويلات الحرارة | MesureConvert</title>
+  <meta name="description" content="قائمة تحويلات الحرارة المتاحة." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="canonical" href="/ar/alhararah/" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "الرئيسية", "item": "/index.html"},
+      {"@type": "ListItem", "position": 2, "name": "الحرارة", "item": "/ar/alhararah/"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/index.html">الرئيسية</a> › الحرارة
+    </nav>
+    <h1>الحرارة</h1>
+    <ul>
+      <li><a href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/">تحويل درجة مئوية إلى فهرنهايت</a></li>
+    </ul>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/en/length/index.html
+++ b/en/length/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Length conversions | MesureConvert</title>
+  <meta name="description" content="List of available length conversions." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="canonical" href="/en/length/" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Home", "item": "/index.html"},
+      {"@type": "ListItem", "position": 2, "name": "Length", "item": "/en/length/"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/index.html">Home</a> › Length
+    </nav>
+    <h1>Length</h1>
+    <ul>
+      <li><a href="/en/length/convert-meter-to-foot/">Convert meter to foot</a></li>
+    </ul>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">About</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Privacy</a>
+      <a href="/conditions-generales.html">Terms</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibility</a>
+      <a href="/securite-des-donnees.html">Data security</a>
+      <a href="/sitemap.html">Sitemap</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/longueur/index.html
+++ b/fr/longueur/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="fr" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <title>Conversions de longueur | MesureConvert</title>
+  <meta name="description" content="Liste des conversions de longueur disponibles." />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="canonical" href="/fr/longueur/" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/index.html"},
+      {"@type": "ListItem", "position": 2, "name": "Longueur", "item": "/fr/longueur/"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/index.html">Accueil</a> › Longueur
+    </nav>
+    <h1>Longueur</h1>
+    <ul>
+      <li><a href="/fr/longueur/convertir-centimetre-en-pouce/">Convertir centimètre en pouce</a></li>
+      <li><a href="/fr/longueur/convertir-metre-en-pied/">Convertir mètre en pied</a></li>
+    </ul>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/hi/lambai/index.html
+++ b/hi/lambai/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="hi" dir="ltr">
+<head>
+  <meta charset="UTF-8" />
+  <title>लंबाई परिवर्तन | MesureConvert</title>
+  <meta name="description" content="उपलब्ध लंबाई रूपांतरणों की सूची।" />
+  <link rel="stylesheet" href="/style.css" />
+  <link rel="canonical" href="/hi/lambai/" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "होम", "item": "/index.html"},
+      {"@type": "ListItem", "position": 2, "name": "लंबाई", "item": "/hi/lambai/"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <nav aria-label="Breadcrumb" class="breadcrumb">
+      <a href="/index.html">होम</a> › लंबाई
+    </nav>
+    <h1>लंबाई</h1>
+    <ul>
+      <li><a href="/hi/lambai/mitar-se-phut-badalna/">मीटर को फ़ुट में बदलें</a></li>
+    </ul>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal index pages for French, English, Hindi, and Arabic conversion categories
- expose existing conversions and breadcrumb metadata for each category

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1849169188329a869ab54b6011514