### PR TITLE
Add category links in homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,16 +63,16 @@
         <section>
             <h2>Convertisseurs par catégorie</h2>
             <ul class="categories">
-                <li>Longueur – Conversions entre m, ft, km, mi, cm, in…</li>
-                <li>Masse – Conversions entre kg, lb, g, oz…</li>
-                <li>Température – Conversions entre °C, °F, K…</li>
-                <li>Volume – Conversions entre L, gal, m³…</li>
-                <li>Aire – Conversions entre m², ft²…</li>
-                <li>Vitesse – Conversions entre km/h, mph…</li>
-                <li>Temps – Conversions entre s, min, h…</li>
-                <li>Énergie – Conversions entre J, kWh…</li>
-                <li>Pression – Conversions entre Pa, bar…</li>
-                <li>Données – Conversions entre Mo, Go…</li>
+                <li><a href="convertisseurs/index.html?cat=length">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
+                <li><a href="convertisseurs/index.html?cat=weight">Masse – Conversions entre kg, lb, g, oz…</a></li>
+                <li><a href="convertisseurs/index.html?cat=temperature">Température – Conversions entre °C, °F, K…</a></li>
+                <li><a href="convertisseurs/index.html?cat=volume">Volume – Conversions entre L, gal, m³…</a></li>
+                <li><a href="convertisseurs/index.html?cat=area">Aire – Conversions entre m², ft²…</a></li>
+                <li><a href="convertisseurs/index.html?cat=speed">Vitesse – Conversions entre km/h, mph…</a></li>
+                <li><a href="convertisseurs/index.html?cat=time">Temps – Conversions entre s, min, h…</a></li>
+                <li><a href="convertisseurs/index.html?cat=energy">Énergie – Conversions entre J, kWh…</a></li>
+                <li><a href="convertisseurs/index.html?cat=pressure">Pression – Conversions entre Pa, bar…</a></li>
+                <li><a href="convertisseurs/index.html?cat=data">Données – Conversions entre Mo, Go…</a></li>
             </ul>
         </section>
         <section>


### PR DESCRIPTION
## Summary
- link each conversion category on the homepage to the converter page with matching category parameter

## Testing
- `for cat in length weight temperature volume area speed time energy pressure data; do if [ -f convertisseurs/index.html ]; then echo "convertisseurs/index.html?cat=$cat OK"; else echo "convertisseurs/index.html?cat=$cat MISSING"; fi; done`
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18490e7d08329b3331a4d09e2af6d