### PR TITLE
Add meta descriptions to static pages

### DIFF
--- a/a-propos.html
+++ b/a-propos.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Découvrez l'objectif et l'équipe derrière Convertisseur Universel." />
     <title>À propos - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/accessibilite.html
+++ b/accessibilite.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Notre engagement pour rendre Convertisseur Universel accessible à tous les utilisateurs." />
     <title>Accessibilité - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/conditions-generales.html
+++ b/conditions-generales.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Conditions générales d'utilisation du site Convertisseur Universel." />
     <title>Conditions générales - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Contactez l'équipe de Convertisseur Universel pour toute question ou suggestion." />
     <title>Contact - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/cookies.html
+++ b/cookies.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Informations sur l'utilisation des cookies et la gestion de vos préférences sur Convertisseur Universel." />
     <title>Cookies - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/politique-de-confidentialite.html
+++ b/politique-de-confidentialite.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Découvrez comment Convertisseur Universel protège et utilise vos données personnelles." />
     <title>Politique de confidentialité - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/securite-des-donnees.html
+++ b/securite-des-donnees.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Mesures de sécurité mises en place pour protéger vos informations sur Convertisseur Universel." />
     <title>Sécurité des données - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>

--- a/sitemap.html
+++ b/sitemap.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Plan du site Convertisseur Universel pour accéder rapidement à toutes les pages." />
     <title>Plan du site - Convertisseur Universel</title>
     <link rel="stylesheet" href="style.css" />
 </head>


### PR DESCRIPTION
## Summary
- add meaningful meta description tags to key informational pages

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1848fd0c88329a250bb23a5a40751