### PR TITLE
Add English and Hindi info pages and update footers

### DIFF
--- a/en/about.html
+++ b/en/about.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>About</h1>
+        <p>This site provides unit conversion tools to simplify everyday calculations.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/accessibility.html
+++ b/en/accessibility.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Accessibility - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Accessibility</h1>
+        <p>We strive to make the site accessible to every user.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/contact.html
+++ b/en/contact.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Contact</h1>
+        <p>For any questions, write to <a href="mailto:info@example.com">info@example.com</a>.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/cookies.html
+++ b/en/cookies.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cookies - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Cookies</h1>
+        <p>We use cookies only for essential site functions.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/data-security.html
+++ b/en/data-security.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data security - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Data security</h1>
+        <p>Protecting your data is our priority.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/length/convert-meter-to-foot/index.html
+++ b/en/length/convert-meter-to-foot/index.html
@@ -138,14 +138,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Privacy</a>
-      <a href="/conditions-generales.html">Terms</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibility</a>
-      <a href="/securite-des-donnees.html">Data security</a>
-      <a href="/sitemap.html">Sitemap</a>
+      <a href="/en/about.html">About</a>
+      <a href="/en/contact.html">Contact</a>
+      <a href="/en/privacy.html">Privacy</a>
+      <a href="/en/terms.html">Terms</a>
+      <a href="/en/cookies.html">Cookies</a>
+      <a href="/en/accessibility.html">Accessibility</a>
+      <a href="/en/data-security.html">Data security</a>
+      <a href="/en/sitemap.html">Sitemap</a>
     </nav>
   </footer>
 </body>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy policy - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Privacy policy</h1>
+        <p>We only collect the data necessary for the site to function and respect your privacy.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/sitemap.html
+++ b/en/sitemap.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sitemap - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Sitemap</h1>
+        <ul>
+            <li><a href="/index.html">Home</a></li>
+            <li><a href="/convertisseurs/index.html">Converters</a></li>
+            <li><a href="/en/about.html">About</a></li>
+            <li><a href="/en/contact.html">Contact</a></li>
+            <li><a href="/en/privacy.html">Privacy policy</a></li>
+            <li><a href="/en/terms.html">Terms</a></li>
+            <li><a href="/en/cookies.html">Cookies</a></li>
+            <li><a href="/en/accessibility.html">Accessibility</a></li>
+            <li><a href="/en/data-security.html">Data security</a></li>
+            <li><a href="/fr/longueur/convertir-metre-en-pied/">Convertir mètre en pied</a></li>
+            <li><a href="/fr/longueur/convertir-centimetre-en-pouce/">Convertir centimètre en pouce</a></li>
+            <li><a href="/en/length/convert-meter-to-foot/">Convert meter to foot</a></li>
+            <li><a href="/hi/lambai/mitar-se-phut-badalna/">मीटर को फ़ुट में बदलें</a></li>
+            <li><a href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/">تحويل درجة مئوية إلى فهرنهايت</a></li>
+        </ul>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/en/terms.html
+++ b/en/terms.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Terms - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>Terms</h1>
+        <p>Use of this site is subject to our terms.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/en/about.html">About</a>
+            <a href="/en/contact.html">Contact</a>
+            <a href="/en/privacy.html">Privacy</a>
+            <a href="/en/terms.html">Terms</a>
+            <a href="/en/cookies.html">Cookies</a>
+            <a href="/en/accessibility.html">Accessibility</a>
+            <a href="/en/data-security.html">Data security</a>
+            <a href="/en/sitemap.html">Sitemap</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/about.html
+++ b/hi/about.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>परिचय - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>परिचय</h1>
+        <p>यह साइट दैनिक गणनाओं को सरल बनाने के लिए यूनिट परिवर्तन उपकरण प्रदान करती है।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/accessibility.html
+++ b/hi/accessibility.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>सुगम्यता - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>सुगम्यता</h1>
+        <p>हम साइट को सभी उपयोगकर्ताओं के लिए सुगम बनाने का प्रयास करते हैं।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/contact.html
+++ b/hi/contact.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>संपर्क - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>संपर्क</h1>
+        <p>किसी भी प्रश्न के लिए हमें <a href="mailto:info@example.com">info@example.com</a> पर लिखें।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/cookies.html
+++ b/hi/cookies.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>कुकीज़ - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>कुकीज़</h1>
+        <p>हम आवश्यक साइट कार्यों के लिए ही कुकीज़ का उपयोग करते हैं।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/data-security.html
+++ b/hi/data-security.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>डेटा सुरक्षा - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>डेटा सुरक्षा</h1>
+        <p>हम आपके डेटा की सुरक्षा को प्राथमिकता देते हैं।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/lambai/mitar-se-phut-badalna/index.html
+++ b/hi/lambai/mitar-se-phut-badalna/index.html
@@ -138,14 +138,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">À propos</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Confidentialité</a>
-      <a href="/conditions-generales.html">Conditions</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibilité</a>
-      <a href="/securite-des-donnees.html">Sécurité des données</a>
-      <a href="/sitemap.html">Plan du site</a>
+      <a href="/hi/about.html">परिचय</a>
+      <a href="/hi/contact.html">संपर्क</a>
+      <a href="/hi/privacy.html">गोपनीयता</a>
+      <a href="/hi/terms.html">नियम</a>
+      <a href="/hi/cookies.html">कुकीज़</a>
+      <a href="/hi/accessibility.html">सुगम्यता</a>
+      <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+      <a href="/hi/sitemap.html">साइट मानचित्र</a>
     </nav>
   </footer>
 </body>

--- a/hi/privacy.html
+++ b/hi/privacy.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>गोपनीयता नीति - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>गोपनीयता नीति</h1>
+        <p>हम साइट संचालन के लिए आवश्यक डेटा ही एकत्र करते हैं और आपकी गोपनीयता का सम्मान करते हैं।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/sitemap.html
+++ b/hi/sitemap.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>साइट मानचित्र - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>साइट मानचित्र</h1>
+        <ul>
+            <li><a href="/index.html">होम</a></li>
+            <li><a href="/convertisseurs/index.html">कनवर्टर्स</a></li>
+            <li><a href="/hi/about.html">परिचय</a></li>
+            <li><a href="/hi/contact.html">संपर्क</a></li>
+            <li><a href="/hi/privacy.html">गोपनीयता नीति</a></li>
+            <li><a href="/hi/terms.html">नियम</a></li>
+            <li><a href="/hi/cookies.html">कुकीज़</a></li>
+            <li><a href="/hi/accessibility.html">सुगम्यता</a></li>
+            <li><a href="/hi/data-security.html">डेटा सुरक्षा</a></li>
+            <li><a href="/fr/longueur/convertir-metre-en-pied/">Convertir mètre en pied</a></li>
+            <li><a href="/fr/longueur/convertir-centimetre-en-pouce/">Convertir centimètre en pouce</a></li>
+            <li><a href="/en/length/convert-meter-to-foot/">Convert meter to foot</a></li>
+            <li><a href="/hi/lambai/mitar-se-phut-badalna/">मीटर को फ़ुट में बदलें</a></li>
+            <li><a href="/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/">تحويل درجة مئوية إلى فهرنهايت</a></li>
+        </ul>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>

--- a/hi/terms.html
+++ b/hi/terms.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="hi">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>नियम - MesureConvert</title>
+    <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+    <header>
+        <p class="site-title"><a href="/index.html">MesureConvert</a></p>
+    </header>
+    <main>
+        <h1>नियम</h1>
+        <p>इस साइट का उपयोग हमारी शर्तों के अधीन है।</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/hi/about.html">परिचय</a>
+            <a href="/hi/contact.html">संपर्क</a>
+            <a href="/hi/privacy.html">गोपनीयता</a>
+            <a href="/hi/terms.html">नियम</a>
+            <a href="/hi/cookies.html">कुकीज़</a>
+            <a href="/hi/accessibility.html">सुगम्यता</a>
+            <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+            <a href="/hi/sitemap.html">साइट मानचित्र</a>
+        </nav>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add translated informational pages in English and Hindi for About, Privacy, Contact, Terms, Cookies, Accessibility, Data security and Sitemap
- Update localized footers to point to appropriate translated pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1849293988329b362499758199d69