### PR TITLE
Add initial structure and sample converter pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Page non trouvée</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <h1>404 - Page non trouvée</h1>
+  <p>La page que vous cherchez n'existe pas.</p>
+  <a href="/">Retour à l'accueil</a>
+</body>
+</html>

--- a/500.html
+++ b/500.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Erreur interne du serveur</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <h1>500 - Erreur interne du serveur</h1>
+  <p>Une erreur inattendue est survenue.</p>
+  <a href="/">Retour à l'accueil</a>
+</body>
+</html>

--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -31,7 +31,7 @@
     <div class="content">
       <ul class="categories">
         <li>Longueur – mesures de m à ft, km, mi…</li>
-        <li>Masse – de g à kg, lb, oz…</li>
+        <li><a href="/convertisseurs/masse/">Masse</a> – de g à kg, lb, oz…</li>
         <li>Température – entre °C, °F, K…</li>
         <li>Volume – litres, gallons, m³…</li>
         <li>Aire – m², ft², hectares…</li>

--- a/convertisseurs/masse/index.html
+++ b/convertisseurs/masse/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertisseurs de masse</title>
+  <meta name="description" content="Outils pour convertir les unités de masse.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Masse"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Masse</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de masse</h1>
+  <ul>
+    <li><a href="kg-vers-g.html">Kilogrammes en grammes</a></li>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Conversion kilogrammes en grammes</title>
+  <meta name="description" content="Convertir des kilogrammes en grammes avec précision.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [{
+      "@type": "Question",
+      "name": "Comment convertir des kilogrammes en grammes&nbsp;?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Multiplier la masse en kilogrammes par 1&nbsp;000."}
+    }],
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+        {"@type": "ListItem", "position": 3, "name": "Masse", "item": "/convertisseurs/masse/"},
+        {"@type": "ListItem", "position": 4, "name": "kg en g"}
+      ]
+    }
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li><a href="/convertisseurs/masse/">Masse</a></li>
+      <li aria-current="page">kg en g</li>
+    </ol>
+  </nav>
+  <h1>Conversion kilogrammes en grammes</h1>
+  <form id="form-convert">
+    <label for="valeur">Valeur en kilogrammes</label>
+    <input id="valeur" name="valeur" type="number" min="0" style="min-width:44px;min-height:44px;">
+    <button type="submit" style="min-width:44px;min-height:44px;">Convertir</button>
+  </form>
+  <div id="badge-precision">BadgePrecision</div>
+  <div id="carte-formule">
+    <h2>Formule</h2>
+    <p>g = kg × 1 000</p>
+  </div>
+  <div id="bloc-exemples">
+    <h2>Exemples</h2>
+    <ul>
+      <li>0,5 kg = 500 g</li>
+      <li>2 kg = 2&nbsp;000 g</li>
+    </ul>
+  </div>
+  <div id="export-resultats"><button style="min-width:44px;min-height:44px;">Exporter</button></div>
+  <div id="alerte-erreur" role="alert" hidden>Valeur invalide</div>
+  <section id="faq-locale">
+    <h2>FAQ</h2>
+    <div>
+      <h3>Pourquoi multiplier par 1&nbsp;000&nbsp;?</h3>
+      <p>Parce qu'un kilogramme vaut mille grammes.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/guides/index.html
+++ b/guides/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Guides pratiques</title>
+  <meta name="description" content="Guides pour comprendre les conversions.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Guides pratiques",
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Guides"}
+      ]
+    }
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li aria-current="page">Guides</li>
+    </ol>
+  </nav>
+  <h1>Guides pratiques</h1>
+  <section>
+    <h2>Introduction</h2>
+    <p>Apprenez à convertir les unités étape par étape.</p>
+  </section>
+  <section>
+    <h2>FAQ</h2>
+    <div>
+      <h3>Pourquoi suivre un guide&nbsp;?</h3>
+      <p>Pour comprendre les formules et éviter les erreurs.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/intl/index.html
+++ b/intl/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Version internationale</title>
+  <meta name="description" content="Accédez aux conversions pour un public international.">
+</head>
+<body>
+  <h1>Version internationale</h1>
+  <p>Bienvenue sur la page dédiée aux utilisateurs du monde entier.</p>
+</body>
+</html>

--- a/lp/index.html
+++ b/lp/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Page de destination</title>
+  <meta name="description" content="Découvrez nos convertisseurs spécialisés.">
+</head>
+<body>
+  <h1>Page de destination</h1>
+  <p>Choisissez l'outil de conversion qui vous convient.</p>
+</body>
+</html>

--- a/outils/index.html
+++ b/outils/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Outils de conversion</title>
+  <meta name="description" content="Outils en ligne pour convertir les unités.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Outils de conversion",
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Outils"}
+      ]
+    }
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li aria-current="page">Outils</li>
+    </ol>
+  </nav>
+  <h1>Outils de conversion</h1>
+  <section>
+    <h2>Convertisseurs</h2>
+    <p>Accédez à nos calculateurs dédiés.</p>
+  </section>
+  <section>
+    <h2>FAQ</h2>
+    <div>
+      <h3>Les outils sont-ils gratuits&nbsp;?</h3>
+      <p>Oui, toutes les conversions sont gratuites.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/tables/index.html
+++ b/tables/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Tables de conversion</title>
+  <meta name="description" content="Tables de conversion pratiques.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Tables de conversion",
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Tables"}
+      ]
+    }
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li aria-current="page">Tables</li>
+    </ol>
+  </nav>
+  <h1>Tables de conversion</h1>
+  <section>
+    <h2>Utilisation</h2>
+    <p>Trouvez rapidement des équivalences entre unités.</p>
+  </section>
+  <section>
+    <h2>FAQ</h2>
+    <div>
+      <h3>Comment lire une table&nbsp;?</h3>
+      <p>Chaque ligne indique l'équivalence entre deux unités.</p>
+    </div>
+  </section>
+</body>
+</html>

--- a/unites/index.html
+++ b/unites/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Unités de mesure</title>
+  <meta name="description" content="Guide des unités de mesure.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Unités de mesure",
+    "breadcrumb": {
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+        {"@type": "ListItem", "position": 2, "name": "Unités"}
+      ]
+    }
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li aria-current="page">Unités</li>
+    </ol>
+  </nav>
+  <h1>Unités de mesure</h1>
+  <section>
+    <h2>Présentation</h2>
+    <p>Cette section décrit différentes unités de mesure.</p>
+  </section>
+  <section>
+    <h2>FAQ</h2>
+    <div>
+      <h3>Qu'est-ce qu'une unité SI&nbsp;?</h3>
+      <p>Une unité du Système international définie par des standards.</p>
+    </div>
+  </section>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add placeholder sections for units, tables, guides, and tools with basic metadata and breadcrumb schema.
- Create sample converter category and kilogram-to-gram page with reusable component placeholders and JSON-LD data.
- Introduce basic error pages (404, 500) and landing stubs for international and landing sections.

## Testing
- `find unites tables guides outils intl lp convertisseurs/masse -maxdepth 1 -type f -print`


------
https://chatgpt.com/codex/tasks/task_e_68c1854b9e248329bbe16d667dc2a9c5