### PR TITLE
Add precision selector to unit converter

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,18 @@
                 <label for="to-unit">À</label>
                 <select id="to-unit"></select>
             </div>
+            <div class="row">
+                <label for="precision">Précision</label>
+                <input type="number" id="precision" min="0" max="6" value="4" />
+            </div>
+            <div class="row">
+                <button id="convert-btn">Convertir</button>
+            </div>
             <div class="row result">
                 <span id="result">0</span>
+            </div>
+            <div class="row">
+                <span id="precision-badge">Précision: 4 décimales</span>
             </div>
         </div>
         <p><a class="cta" href="convertisseurs/index.html">Ouvrir le convertisseur</a></p>

--- a/script.js
+++ b/script.js
@@ -146,6 +146,14 @@ const fromValue = document.getElementById('from-value');
 const fromUnit = document.getElementById('from-unit');
 const toUnit = document.getElementById('to-unit');
 const resultSpan = document.getElementById('result');
+const precisionInput = document.getElementById('precision');
+const precisionBadge = document.getElementById('precision-badge');
+const convertBtn = document.getElementById('convert-btn');
+
+function updatePrecisionBadge() {
+    const p = parseInt(precisionInput.value, 10) || 0;
+    precisionBadge.textContent = `Précision: ${p} décimales`;
+}
 
 function populateUnits(cat) {
     const units = categories[cat].units;
@@ -172,6 +180,7 @@ function convert() {
     const value = parseFloat(fromValue.value);
     const from = fromUnit.value;
     const to = toUnit.value;
+    const precision = parseInt(precisionInput.value, 10) || 0;
 
     if (isNaN(value)) {
         resultSpan.textContent = '—';
@@ -190,7 +199,7 @@ function convert() {
     if (typeof result === 'undefined' || isNaN(result)) {
         resultSpan.textContent = 'Conversion impossible';
     } else {
-        resultSpan.textContent = result.toFixed(4);
+        resultSpan.textContent = result.toFixed(precision);
     }
 }
 
@@ -230,7 +239,13 @@ categorySelect.addEventListener('change', () => {
 fromValue.addEventListener('input', convert);
 fromUnit.addEventListener('change', convert);
 toUnit.addEventListener('change', convert);
+precisionInput.addEventListener('input', () => {
+    updatePrecisionBadge();
+    convert();
+});
+convertBtn.addEventListener('click', convert);
 
 // Initialize
 populateUnits(categorySelect.value);
+updatePrecisionBadge();
 convert();

--- a/style.css
+++ b/style.css
@@ -52,11 +52,29 @@ main {
     font-size: 1rem;
 }
 
+.row button {
+    padding: 0.5rem;
+    border: 1px solid #d2d2d7;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    background: #007acc;
+    color: #fff;
+    cursor: pointer;
+}
+
 .result {
     text-align: center;
     font-size: 2rem;
     font-weight: 600;
     margin-top: 1rem;
+}
+
+#precision-badge {
+    display: inline-block;
+    background: #e5e5ea;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
 }
 .site-title {
     margin: 0;


### PR DESCRIPTION
## Summary
- add precision field and Convertir button to home page converter
- display badge showing selected decimal precision
- round conversion results according to selected precision

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1864076808329a6ff61d1da7e1000