### PR TITLE
fix: use english footer links on length page

### DIFF
--- a/en/length/index.html
+++ b/en/length/index.html
@@ -32,14 +32,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Privacy</a>
-      <a href="/conditions-generales.html">Terms</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibility</a>
-      <a href="/securite-des-donnees.html">Data security</a>
-      <a href="/sitemap.html">Sitemap</a>
+      <a href="/en/about.html">About</a>
+      <a href="/en/contact.html">Contact</a>
+      <a href="/en/privacy.html">Privacy</a>
+      <a href="/en/terms.html">Terms</a>
+      <a href="/en/cookies.html">Cookies</a>
+      <a href="/en/accessibility.html">Accessibility</a>
+      <a href="/en/data-security.html">Data security</a>
+      <a href="/en/sitemap.html">Sitemap</a>
     </nav>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- point English length page footer links to English pages
- verified other English pages already use English footer structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c18759cb0083298e0316898dd8bb52