### PR TITLE
Add meta descriptions to English info pages

### DIFF
--- a/en/about.html
+++ b/en/about.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Learn about MesureConvert and its mission to simplify unit conversions." />
     <title>About - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/accessibility.html
+++ b/en/accessibility.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Discover our commitment to making MesureConvert accessible to all users." />
     <title>Accessibility - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/contact.html
+++ b/en/contact.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Get in touch with MesureConvert for questions or support." />
     <title>Contact - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/cookies.html
+++ b/en/cookies.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Find out how MesureConvert uses essential cookies and your options." />
     <title>Cookies - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/data-security.html
+++ b/en/data-security.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="See the measures MesureConvert takes to keep your information secure." />
     <title>Data security - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/privacy.html
+++ b/en/privacy.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Understand how MesureConvert collects and protects your personal data." />
     <title>Privacy policy - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/sitemap.html
+++ b/en/sitemap.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Browse the full sitemap to explore every section of MesureConvert." />
     <title>Sitemap - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>

--- a/en/terms.html
+++ b/en/terms.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Review the terms of use governing MesureConvert." />
     <title>Terms - MesureConvert</title>
     <link rel="stylesheet" href="/style.css" />
 </head>


### PR DESCRIPTION
## Summary
- add SEO-friendly meta descriptions to English about, contact, privacy, terms, cookies, accessibility, data-security, and sitemap pages

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1875ab37c8329a9fb9d06a449a465