### PR TITLE
Localize footer links for language-specific pages

### DIFF
--- a/ar/alhararah/index.html
+++ b/ar/alhararah/index.html
@@ -32,14 +32,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">À propos</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Confidentialité</a>
-      <a href="/conditions-generales.html">Conditions</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibilité</a>
-      <a href="/securite-des-donnees.html">Sécurité des données</a>
-      <a href="/sitemap.html">Plan du site</a>
+      <a href="/ar/about.html">حول</a>
+      <a href="/ar/contact.html">اتصل بنا</a>
+      <a href="/ar/privacy.html">الخصوصية</a>
+      <a href="/ar/terms.html">الشروط</a>
+      <a href="/ar/cookies.html">الكوكيز</a>
+      <a href="/ar/accessibility.html">إمكانية الوصول</a>
+      <a href="/ar/data-security.html">أمن البيانات</a>
+      <a href="/ar/sitemap.html">خريطة الموقع</a>
     </nav>
   </footer>
 </body>

--- a/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
+++ b/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
@@ -135,14 +135,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">À propos</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Confidentialité</a>
-      <a href="/conditions-generales.html">Conditions</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibilité</a>
-      <a href="/securite-des-donnees.html">Sécurité des données</a>
-      <a href="/sitemap.html">Plan du site</a>
+      <a href="/ar/about.html">حول</a>
+      <a href="/ar/contact.html">اتصل بنا</a>
+      <a href="/ar/privacy.html">الخصوصية</a>
+      <a href="/ar/terms.html">الشروط</a>
+      <a href="/ar/cookies.html">الكوكيز</a>
+      <a href="/ar/accessibility.html">إمكانية الوصول</a>
+      <a href="/ar/data-security.html">أمن البيانات</a>
+      <a href="/ar/sitemap.html">خريطة الموقع</a>
     </nav>
   </footer>
 </body>

--- a/en/length/index.html
+++ b/en/length/index.html
@@ -32,14 +32,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">About</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Privacy</a>
-      <a href="/conditions-generales.html">Terms</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibility</a>
-      <a href="/securite-des-donnees.html">Data security</a>
-      <a href="/sitemap.html">Sitemap</a>
+      <a href="/en/about.html">About</a>
+      <a href="/en/contact.html">Contact</a>
+      <a href="/en/privacy.html">Privacy</a>
+      <a href="/en/terms.html">Terms</a>
+      <a href="/en/cookies.html">Cookies</a>
+      <a href="/en/accessibility.html">Accessibility</a>
+      <a href="/en/data-security.html">Data security</a>
+      <a href="/en/sitemap.html">Sitemap</a>
     </nav>
   </footer>
 </body>

--- a/hi/lambai/index.html
+++ b/hi/lambai/index.html
@@ -32,14 +32,14 @@
   </main>
   <footer>
     <nav>
-      <a href="/a-propos.html">À propos</a>
-      <a href="/contact.html">Contact</a>
-      <a href="/politique-de-confidentialite.html">Confidentialité</a>
-      <a href="/conditions-generales.html">Conditions</a>
-      <a href="/cookies.html">Cookies</a>
-      <a href="/accessibilite.html">Accessibilité</a>
-      <a href="/securite-des-donnees.html">Sécurité des données</a>
-      <a href="/sitemap.html">Plan du site</a>
+      <a href="/hi/about.html">परिचय</a>
+      <a href="/hi/contact.html">संपर्क</a>
+      <a href="/hi/privacy.html">गोपनीयता</a>
+      <a href="/hi/terms.html">नियम</a>
+      <a href="/hi/cookies.html">कुकीज़</a>
+      <a href="/hi/accessibility.html">सुगम्यता</a>
+      <a href="/hi/data-security.html">डेटा सुरक्षा</a>
+      <a href="/hi/sitemap.html">साइट मानचित्र</a>
     </nav>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- Use Hindi URLs in `hi/lambai/index.html`
- Use Arabic URLs in `ar/alhararah/index.html` and its Fahrenheit conversion subpage
- Use English URLs in `en/length/index.html`

## Testing
- `npm test` (fails: missing package.json)
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c1875c7aa083299cc6d77bc8ab95a1