### PR TITLE
Add viewport meta to error pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page non trouvée</title>
   <meta name="robots" content="noindex">
 </head>

--- a/500.html
+++ b/500.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Erreur interne du serveur</title>
   <meta name="robots" content="noindex">
 </head>


### PR DESCRIPTION
## Summary
- Add viewport meta tag to 404 and 500 error pages for responsive layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c187e3268883299ce132bfc160ceb8