### PR TITLE
chore: set MesureConvert as site title

### DIFF
--- a/a-propos.html
+++ b/a-propos.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>À propos</h1>

--- a/accessibilite.html
+++ b/accessibilite.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Accessibilité</h1>

--- a/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
+++ b/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
@@ -42,7 +42,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <nav aria-label="Breadcrumb" class="breadcrumb">

--- a/conditions-generales.html
+++ b/conditions-generales.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Conditions générales</h1>

--- a/contact.html
+++ b/contact.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Contact</h1>

--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -23,7 +23,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <h1>Tous les convertisseurs par catégorie</h1>

--- a/cookies.html
+++ b/cookies.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Cookies</h1>

--- a/en/length/convert-meter-to-foot/index.html
+++ b/en/length/convert-meter-to-foot/index.html
@@ -44,7 +44,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <nav aria-label="Breadcrumb" class="breadcrumb">

--- a/fr/longueur/convertir-centimetre-en-pouce/index.html
+++ b/fr/longueur/convertir-centimetre-en-pouce/index.html
@@ -41,7 +41,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <nav aria-label="Breadcrumb" class="breadcrumb">

--- a/fr/longueur/convertir-metre-en-pied/index.html
+++ b/fr/longueur/convertir-metre-en-pied/index.html
@@ -44,7 +44,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <nav aria-label="Breadcrumb" class="breadcrumb">

--- a/hi/lambai/mitar-se-phut-badalna/index.html
+++ b/hi/lambai/mitar-se-phut-badalna/index.html
@@ -44,7 +44,7 @@
 </head>
 <body>
   <header>
-    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    <p class="site-title"><a href="/index.html">MesureConvert</a></p>
   </header>
   <main>
     <nav aria-label="Breadcrumb" class="breadcrumb">

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Convertisseurs d’unités fiables, instantanés.</h1>

--- a/politique-de-confidentialite.html
+++ b/politique-de-confidentialite.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Politique de confidentialité</h1>

--- a/securite-des-donnees.html
+++ b/securite-des-donnees.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Sécurité des données</h1>

--- a/sitemap.html
+++ b/sitemap.html
@@ -9,7 +9,7 @@
 </head>
 <body>
     <header>
-        <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+        <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
         <h1>Plan du site</h1>


### PR DESCRIPTION
## Summary
- standardize `<p class="site-title">` across pages to the MesureConvert brand
- confirm Open Graph `og:site_name` uses MesureConvert

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c187623c7c83298668ca7d2633f5d0