### PR TITLE
Add viewport meta tag to HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page non trouvée</title>
   <meta name="robots" content="noindex">
 </head>

--- a/500.html
+++ b/500.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Erreur interne du serveur</title>
   <meta name="robots" content="noindex">
 </head>

--- a/ar/alhararah/index.html
+++ b/ar/alhararah/index.html
@@ -2,6 +2,7 @@
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>تحويلات الحرارة | MesureConvert</title>
   <meta name="description" content="قائمة تحويلات الحرارة المتاحة." />
   <link rel="stylesheet" href="/style.css" />

--- a/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
+++ b/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
@@ -2,6 +2,7 @@
 <html lang="ar" dir="rtl">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>تحويل درجة مئوية إلى فهرنهايت | MesureConvert</title>
   <meta name="description" content="حوّل درجات الحرارة من مئوية إلى فهرنهايت باستخدام أداة MesureConvert البسيطة. نتائج فورية للمشاريع المنزلية أو الدراسة أو السفر." />
   <link rel="stylesheet" href="/style.css" />

--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tous les convertisseurs d’unités | MesureConvert</title>
   <meta name="description" content="Accédez aux convertisseurs par catégorie. Longueur, masse, température, etc." />
   <meta property="og:type" content="website" />

--- a/convertisseurs/masse/index.html
+++ b/convertisseurs/masse/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Convertisseurs de masse</title>
   <meta name="description" content="Outils pour convertir les unités de masse.">
   <script type="application/ld+json">

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Conversion kilogrammes en grammes</title>
   <meta name="description" content="Convertir des kilogrammes en grammes avec précision.">
   <script type="application/ld+json">

--- a/en/length/convert-meter-to-foot/index.html
+++ b/en/length/convert-meter-to-foot/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Convert meter to foot | MesureConvert</title>
   <meta name="description" content="Convert meters to feet with MesureConvert, a clear and reliable tool. Instant calculations for home projects, studies, or travel planning." />
   <link rel="stylesheet" href="/style.css" />

--- a/en/length/index.html
+++ b/en/length/index.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Length conversions | MesureConvert</title>
   <meta name="description" content="List of available length conversions." />
   <link rel="stylesheet" href="/style.css" />

--- a/fr/longueur/convertir-centimetre-en-pouce/index.html
+++ b/fr/longueur/convertir-centimetre-en-pouce/index.html
@@ -2,6 +2,7 @@
 <html lang="fr" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Convertir centimètre en pouce | MesureConvert</title>
   <meta name="description" content="Transformez vos mesures de centimètre en pouce grâce à l’outil MesureConvert, simple et fiable." />
   <link rel="stylesheet" href="/style.css" />

--- a/fr/longueur/convertir-metre-en-pied/index.html
+++ b/fr/longueur/convertir-metre-en-pied/index.html
@@ -2,6 +2,7 @@
 <html lang="fr" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Convertir mètre en pied | MesureConvert</title>
   <meta name="description" content="Transformez vos mesures de mètre en pied grâce à l’outil MesureConvert, simple et fiable. Calculs instantanés pour projets maison, études ou voyages pratiques." />
   <link rel="stylesheet" href="/style.css" />

--- a/fr/longueur/index.html
+++ b/fr/longueur/index.html
@@ -2,6 +2,7 @@
 <html lang="fr" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Conversions de longueur | MesureConvert</title>
   <meta name="description" content="Liste des conversions de longueur disponibles." />
   <link rel="stylesheet" href="/style.css" />

--- a/guides/index.html
+++ b/guides/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Guides pratiques</title>
   <meta name="description" content="Guides pour comprendre les conversions.">
   <script type="application/ld+json">

--- a/hi/lambai/index.html
+++ b/hi/lambai/index.html
@@ -2,6 +2,7 @@
 <html lang="hi" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>लंबाई परिवर्तन | MesureConvert</title>
   <meta name="description" content="उपलब्ध लंबाई रूपांतरणों की सूची।" />
   <link rel="stylesheet" href="/style.css" />

--- a/hi/lambai/mitar-se-phut-badalna/index.html
+++ b/hi/lambai/mitar-se-phut-badalna/index.html
@@ -2,6 +2,7 @@
 <html lang="hi" dir="ltr">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>मीटर को फ़ुट में बदलें | MesureConvert</title>
   <meta name="description" content="MesureConvert से मीटर को फ़ुट में तुरंत बदलें। यह सरल उपकरण घर, पढ़ाई या यात्रा की योजनाओं के लिए उपयोगी है।" />
   <link rel="stylesheet" href="/style.css" />

--- a/intl/index.html
+++ b/intl/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Version internationale</title>
   <meta name="description" content="Accédez aux conversions pour un public international.">
 </head>

--- a/lp/index.html
+++ b/lp/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Page de destination</title>
   <meta name="description" content="Découvrez nos convertisseurs spécialisés.">
 </head>

--- a/outils/index.html
+++ b/outils/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Outils de conversion</title>
   <meta name="description" content="Outils en ligne pour convertir les unités.">
   <script type="application/ld+json">

--- a/tables/index.html
+++ b/tables/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tables de conversion</title>
   <meta name="description" content="Tables de conversion pratiques.">
   <script type="application/ld+json">

--- a/unites/index.html
+++ b/unites/index.html
@@ -2,6 +2,7 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Unités de mesure</title>
   <meta name="description" content="Guide des unités de mesure.">
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- insert `<meta name="viewport" content="width=device-width, initial-scale=1.0">` into every HTML page lacking the tag
- ensure consistent mobile responsiveness across site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c187df06b083299e6cd7ffcf9795f3