### PR TITLE
feat: add header and footer to tables and unites pages

### DIFF
--- a/tables/index.html
+++ b/tables/index.html
@@ -20,23 +20,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Tables</li>
-    </ol>
-  </nav>
-  <h1>Tables de conversion</h1>
-  <section>
-    <h2>Utilisation</h2>
-    <p>Trouvez rapidement des équivalences entre unités.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Comment lire une table&nbsp;?</h3>
-      <p>Chaque ligne indique l'équivalence entre deux unités.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Tables</li>
+      </ol>
+    </nav>
+    <h1>Tables de conversion</h1>
+    <section>
+      <h2>Utilisation</h2>
+      <p>Trouvez rapidement des équivalences entre unités.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Comment lire une table&nbsp;?</h3>
+        <p>Chaque ligne indique l'équivalence entre deux unités.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/unites/index.html
+++ b/unites/index.html
@@ -20,23 +20,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Unités</li>
-    </ol>
-  </nav>
-  <h1>Unités de mesure</h1>
-  <section>
-    <h2>Présentation</h2>
-    <p>Cette section décrit différentes unités de mesure.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Qu'est-ce qu'une unité SI&nbsp;?</h3>
-      <p>Une unité du Système international définie par des standards.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Unités</li>
+      </ol>
+    </nav>
+    <h1>Unités de mesure</h1>
+    <section>
+      <h2>Présentation</h2>
+      <p>Cette section décrit différentes unités de mesure.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Qu'est-ce qu'une unité SI&nbsp;?</h3>
+        <p>Une unité du Système international définie par des standards.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add site header with home link to tables and unites pages
- include standard footer navigation on tables and unites pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c187e5bb0483298029f88b89d44c40