### PR TITLE
Add standard footer to intl and lp pages

### DIFF
--- a/intl/index.html
+++ b/intl/index.html
@@ -1,12 +1,31 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <title>Version internationale</title>
-  <meta name="description" content="Accédez aux conversions pour un public international.">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Version internationale</title>
+    <meta name="description" content="Accédez aux conversions pour un public international." />
+    <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>Version internationale</h1>
-  <p>Bienvenue sur la page dédiée aux utilisateurs du monde entier.</p>
+    <header>
+        <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Version internationale</h1>
+        <p>Bienvenue sur la page dédiée aux utilisateurs du monde entier.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/a-propos.html">À propos</a>
+            <a href="/contact.html">Contact</a>
+            <a href="/politique-de-confidentialite.html">Confidentialité</a>
+            <a href="/conditions-generales.html">Conditions</a>
+            <a href="/cookies.html">Cookies</a>
+            <a href="/accessibilite.html">Accessibilité</a>
+            <a href="/securite-des-donnees.html">Sécurité des données</a>
+            <a href="/sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
 </body>
 </html>

--- a/lp/index.html
+++ b/lp/index.html
@@ -1,12 +1,31 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <title>Page de destination</title>
-  <meta name="description" content="Découvrez nos convertisseurs spécialisés.">
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page de destination</title>
+    <meta name="description" content="Découvrez nos convertisseurs spécialisés." />
+    <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>Page de destination</h1>
-  <p>Choisissez l'outil de conversion qui vous convient.</p>
+    <header>
+        <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+    </header>
+    <main>
+        <h1>Page de destination</h1>
+        <p>Choisissez l'outil de conversion qui vous convient.</p>
+    </main>
+    <footer>
+        <nav>
+            <a href="/a-propos.html">À propos</a>
+            <a href="/contact.html">Contact</a>
+            <a href="/politique-de-confidentialite.html">Confidentialité</a>
+            <a href="/conditions-generales.html">Conditions</a>
+            <a href="/cookies.html">Cookies</a>
+            <a href="/accessibilite.html">Accessibilité</a>
+            <a href="/securite-des-donnees.html">Sécurité des données</a>
+            <a href="/sitemap.html">Plan du site</a>
+        </nav>
+    </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add site header and standard footer navigation to international and landing pages
- include stylesheet link and main sections for consistency

## Testing
- `npm test` *(command not found)*
- `apt-get update` *(403 error: repository is not signed)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c187e3b3908329814783527b880188