### PR TITLE
Ajoute structures sémantiques aux pages manquantes

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,13 +1,32 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <title>Page non trouvée</title>
-  <meta name="robots" content="noindex">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page non trouvée - Convertisseur Universel</title>
+  <meta name="robots" content="noindex" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>404 - Page non trouvée</h1>
-  <p>La page que vous cherchez n'existe pas.</p>
-  <a href="/">Retour à l'accueil</a>
+  <header>
+    <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>404 - Page non trouvée</h1>
+    <p>La page que vous cherchez n'existe pas.</p>
+    <a href="/">Retour à l'accueil</a>
+  </main>
+  <footer>
+    <nav>
+      <a href="a-propos.html">À propos</a>
+      <a href="contact.html">Contact</a>
+      <a href="politique-de-confidentialite.html">Confidentialité</a>
+      <a href="conditions-generales.html">Conditions</a>
+      <a href="cookies.html">Cookies</a>
+      <a href="accessibilite.html">Accessibilité</a>
+      <a href="securite-des-donnees.html">Sécurité des données</a>
+      <a href="sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/500.html
+++ b/500.html
@@ -1,13 +1,32 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <title>Erreur interne du serveur</title>
-  <meta name="robots" content="noindex">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Erreur interne du serveur - Convertisseur Universel</title>
+  <meta name="robots" content="noindex" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>500 - Erreur interne du serveur</h1>
-  <p>Une erreur inattendue est survenue.</p>
-  <a href="/">Retour à l'accueil</a>
+  <header>
+    <p class="site-title"><a href="index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>500 - Erreur interne du serveur</h1>
+    <p>Une erreur inattendue est survenue.</p>
+    <a href="/">Retour à l'accueil</a>
+  </main>
+  <footer>
+    <nav>
+      <a href="a-propos.html">À propos</a>
+      <a href="contact.html">Contact</a>
+      <a href="politique-de-confidentialite.html">Confidentialité</a>
+      <a href="conditions-generales.html">Conditions</a>
+      <a href="cookies.html">Cookies</a>
+      <a href="accessibilite.html">Accessibilité</a>
+      <a href="securite-des-donnees.html">Sécurité des données</a>
+      <a href="sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/convertisseurs/masse/index.html
+++ b/convertisseurs/masse/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Convertisseurs de masse</title>
-  <meta name="description" content="Outils pour convertir les unités de masse.">
+  <meta name="description" content="Outils pour convertir les unités de masse." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -17,16 +19,33 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li><a href="/convertisseurs/">Convertisseurs</a></li>
-      <li aria-current="page">Masse</li>
-    </ol>
-  </nav>
-  <h1>Convertisseurs de masse</h1>
-  <ul>
-    <li><a href="kg-vers-g.html">Kilogrammes en grammes</a></li>
-  </ul>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/convertisseurs/">Convertisseurs</a></li>
+        <li aria-current="page">Masse</li>
+      </ol>
+    </nav>
+    <h1>Convertisseurs de masse</h1>
+    <ul>
+      <li><a href="kg-vers-g.html">Kilogrammes en grammes</a></li>
+    </ul>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Conversion kilogrammes en grammes</title>
-  <meta name="description" content="Convertir des kilogrammes en grammes avec précision.">
+  <meta name="description" content="Convertir des kilogrammes en grammes avec précision." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "FAQPage",
     "mainEntity": [{
       "@type": "Question",
-      "name": "Comment convertir des kilogrammes en grammes&nbsp;?",
-      "acceptedAnswer": {"@type": "Answer", "text": "Multiplier la masse en kilogrammes par 1&nbsp;000."}
+      "name": "Comment convertir des kilogrammes en grammes ?",
+      "acceptedAnswer": {"@type": "Answer", "text": "Multiplier la masse en kilogrammes par 1 000."}
     }],
     "breadcrumb": {
       "@type": "BreadcrumbList",
@@ -26,40 +28,57 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li><a href="/convertisseurs/">Convertisseurs</a></li>
-      <li><a href="/convertisseurs/masse/">Masse</a></li>
-      <li aria-current="page">kg en g</li>
-    </ol>
-  </nav>
-  <h1>Conversion kilogrammes en grammes</h1>
-  <form id="form-convert">
-    <label for="valeur">Valeur en kilogrammes</label>
-    <input id="valeur" name="valeur" type="number" min="0" style="min-width:44px;min-height:44px;">
-    <button type="submit" style="min-width:44px;min-height:44px;">Convertir</button>
-  </form>
-  <div id="badge-precision">BadgePrecision</div>
-  <div id="carte-formule">
-    <h2>Formule</h2>
-    <p>g = kg × 1 000</p>
-  </div>
-  <div id="bloc-exemples">
-    <h2>Exemples</h2>
-    <ul>
-      <li>0,5 kg = 500 g</li>
-      <li>2 kg = 2&nbsp;000 g</li>
-    </ul>
-  </div>
-  <div id="export-resultats"><button style="min-width:44px;min-height:44px;">Exporter</button></div>
-  <div id="alerte-erreur" role="alert" hidden>Valeur invalide</div>
-  <section id="faq-locale">
-    <h2>FAQ</h2>
-    <div>
-      <h3>Pourquoi multiplier par 1&nbsp;000&nbsp;?</h3>
-      <p>Parce qu'un kilogramme vaut mille grammes.</p>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li><a href="/convertisseurs/">Convertisseurs</a></li>
+        <li><a href="/convertisseurs/masse/">Masse</a></li>
+        <li aria-current="page">kg en g</li>
+      </ol>
+    </nav>
+    <h1>Conversion kilogrammes en grammes</h1>
+    <form id="form-convert">
+      <label for="valeur">Valeur en kilogrammes</label>
+      <input id="valeur" name="valeur" type="number" min="0" style="min-width:44px;min-height:44px;" />
+      <button type="submit" style="min-width:44px;min-height:44px;">Convertir</button>
+    </form>
+    <div id="badge-precision">BadgePrecision</div>
+    <div id="carte-formule">
+      <h2>Formule</h2>
+      <p>g = kg × 1 000</p>
     </div>
-  </section>
+    <div id="bloc-exemples">
+      <h2>Exemples</h2>
+      <ul>
+        <li>0,5 kg = 500 g</li>
+        <li>2 kg = 2 000 g</li>
+      </ul>
+    </div>
+    <div id="export-resultats"><button style="min-width:44px;min-height:44px;">Exporter</button></div>
+    <div id="alerte-erreur" role="alert" hidden>Valeur invalide</div>
+    <section id="faq-locale">
+      <h2>FAQ</h2>
+      <div>
+        <h3>Pourquoi multiplier par 1 000 ?</h3>
+        <p>Parce qu'un kilogramme vaut mille grammes.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/guides/index.html
+++ b/guides/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Guides pratiques</title>
-  <meta name="description" content="Guides pour comprendre les conversions.">
+  <meta name="description" content="Guides pour comprendre les conversions." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -20,23 +22,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Guides</li>
-    </ol>
-  </nav>
-  <h1>Guides pratiques</h1>
-  <section>
-    <h2>Introduction</h2>
-    <p>Apprenez à convertir les unités étape par étape.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Pourquoi suivre un guide&nbsp;?</h3>
-      <p>Pour comprendre les formules et éviter les erreurs.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Guides</li>
+      </ol>
+    </nav>
+    <h1>Guides pratiques</h1>
+    <section>
+      <h2>Introduction</h2>
+      <p>Apprenez à convertir les unités étape par étape.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Pourquoi suivre un guide ?</h3>
+        <p>Pour comprendre les formules et éviter les erreurs.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/intl/index.html
+++ b/intl/index.html
@@ -1,12 +1,31 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Version internationale</title>
-  <meta name="description" content="Accédez aux conversions pour un public international.">
+  <meta name="description" content="Accédez aux conversions pour un public international." />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>Version internationale</h1>
-  <p>Bienvenue sur la page dédiée aux utilisateurs du monde entier.</p>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Version internationale</h1>
+    <p>Bienvenue sur la page dédiée aux utilisateurs du monde entier.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/lp/index.html
+++ b/lp/index.html
@@ -1,12 +1,31 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page de destination</title>
-  <meta name="description" content="Découvrez nos convertisseurs spécialisés.">
+  <meta name="description" content="Découvrez nos convertisseurs spécialisés." />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>Page de destination</h1>
-  <p>Choisissez l'outil de conversion qui vous convient.</p>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Page de destination</h1>
+    <p>Choisissez l'outil de conversion qui vous convient.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/outils/index.html
+++ b/outils/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Outils de conversion</title>
-  <meta name="description" content="Outils en ligne pour convertir les unités.">
+  <meta name="description" content="Outils en ligne pour convertir les unités." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -20,23 +22,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Outils</li>
-    </ol>
-  </nav>
-  <h1>Outils de conversion</h1>
-  <section>
-    <h2>Convertisseurs</h2>
-    <p>Accédez à nos calculateurs dédiés.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Les outils sont-ils gratuits&nbsp;?</h3>
-      <p>Oui, toutes les conversions sont gratuites.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Outils</li>
+      </ol>
+    </nav>
+    <h1>Outils de conversion</h1>
+    <section>
+      <h2>Convertisseurs</h2>
+      <p>Accédez à nos calculateurs dédiés.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Les outils sont-ils gratuits ?</h3>
+        <p>Oui, toutes les conversions sont gratuites.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/tables/index.html
+++ b/tables/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Tables de conversion</title>
-  <meta name="description" content="Tables de conversion pratiques.">
+  <meta name="description" content="Tables de conversion pratiques." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -20,23 +22,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Tables</li>
-    </ol>
-  </nav>
-  <h1>Tables de conversion</h1>
-  <section>
-    <h2>Utilisation</h2>
-    <p>Trouvez rapidement des équivalences entre unités.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Comment lire une table&nbsp;?</h3>
-      <p>Chaque ligne indique l'équivalence entre deux unités.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Tables</li>
+      </ol>
+    </nav>
+    <h1>Tables de conversion</h1>
+    <section>
+      <h2>Utilisation</h2>
+      <p>Trouvez rapidement des équivalences entre unités.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Comment lire une table ?</h3>
+        <p>Chaque ligne indique l'équivalence entre deux unités.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/unites/index.html
+++ b/unites/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Unités de mesure</title>
-  <meta name="description" content="Guide des unités de mesure.">
+  <meta name="description" content="Guide des unités de mesure." />
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -20,23 +22,40 @@
   </script>
 </head>
 <body>
-  <nav aria-label="Fil d'Ariane">
-    <ol>
-      <li><a href="/">Accueil</a></li>
-      <li aria-current="page">Unités</li>
-    </ol>
-  </nav>
-  <h1>Unités de mesure</h1>
-  <section>
-    <h2>Présentation</h2>
-    <p>Cette section décrit différentes unités de mesure.</p>
-  </section>
-  <section>
-    <h2>FAQ</h2>
-    <div>
-      <h3>Qu'est-ce qu'une unité SI&nbsp;?</h3>
-      <p>Une unité du Système international définie par des standards.</p>
-    </div>
-  </section>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <nav aria-label="Fil d'Ariane">
+      <ol>
+        <li><a href="/">Accueil</a></li>
+        <li aria-current="page">Unités</li>
+      </ol>
+    </nav>
+    <h1>Unités de mesure</h1>
+    <section>
+      <h2>Présentation</h2>
+      <p>Cette section décrit différentes unités de mesure.</p>
+    </section>
+    <section>
+      <h2>FAQ</h2>
+      <div>
+        <h3>Qu'est-ce qu'une unité SI&nbsp;?</h3>
+        <p>Une unité du Système international définie par des standards.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Encadre le contenu principal par `<main>` sur toutes les pages dépourvues
- Ajoute en-tête et pied de page cohérents pour la navigation du site
- Vérifie et normalise la hiérarchie des titres dans chaque `<main>`

## Testing
- `npm test` *(échoue : package.json manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68c187e12c0083298e2855bd47411b72