### PR TITLE
Remove PHP file references in site structure

### DIFF
--- a/structure.txt
+++ b/structure.txt
@@ -309,6 +309,4 @@
 /sound-converter.html
 /typography-converter.html
 /volume-lumber-converter.html
-/common-unit-systems.php
-/about-us.php
-/sitemap.php
+/sitemap.html


### PR DESCRIPTION
## Summary
- cleanse legacy PHP links from site structure
- standardize sitemap link to HTML extension

## Testing
- `rg '\.php' -n || true`
- `npm test` *(fails: command not found)*
- `apt-get update`
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c187d50e8c8329bf859094b0e98d04