### PR TITLE
Link popular conversions and add placeholder pages

### DIFF
--- a/fr/donnees/convertir-megaoctet-en-gigaoctet/index.html
+++ b/fr/donnees/convertir-megaoctet-en-gigaoctet/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir mégaoctet en gigaoctet</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir mégaoctet en gigaoctet</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/energie/convertir-joule-en-kilowatt-heure/index.html
+++ b/fr/energie/convertir-joule-en-kilowatt-heure/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir joule en kilowatt-heure</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir joule en kilowatt-heure</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/masse/convertir-kilogramme-en-livre/index.html
+++ b/fr/masse/convertir-kilogramme-en-livre/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir kilogramme en livre</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir kilogramme en livre</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/pression/convertir-pascal-en-bar/index.html
+++ b/fr/pression/convertir-pascal-en-bar/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir pascal en bar</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir pascal en bar</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/temperature/convertir-degre-celsius-en-degre-fahrenheit/index.html
+++ b/fr/temperature/convertir-degre-celsius-en-degre-fahrenheit/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir degré Celsius en degré Fahrenheit</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir degré Celsius en degré Fahrenheit</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/temps/convertir-seconde-en-minute/index.html
+++ b/fr/temps/convertir-seconde-en-minute/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir seconde en minute</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir seconde en minute</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/vitesse/convertir-kilometre-par-heure-en-mile-par-heure/index.html
+++ b/fr/vitesse/convertir-kilometre-par-heure-en-mile-par-heure/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir kilomètre par heure en mile par heure</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir kilomètre par heure en mile par heure</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/fr/volume/convertir-litre-en-gallon/index.html
+++ b/fr/volume/convertir-litre-en-gallon/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Convertir litre en gallon</title>
+  <link rel="stylesheet" href="/style.css" />
+</head>
+<body>
+  <header>
+    <p class="site-title"><a href="/index.html">Convertisseur Universel</a></p>
+  </header>
+  <main>
+    <h1>Convertir litre en gallon</h1>
+    <p>Page en construction.</p>
+  </main>
+  <footer>
+    <nav>
+      <a href="/a-propos.html">À propos</a>
+      <a href="/contact.html">Contact</a>
+      <a href="/politique-de-confidentialite.html">Confidentialité</a>
+      <a href="/conditions-generales.html">Conditions</a>
+      <a href="/cookies.html">Cookies</a>
+      <a href="/accessibilite.html">Accessibilité</a>
+      <a href="/securite-des-donnees.html">Sécurité des données</a>
+      <a href="/sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -90,14 +90,14 @@
             <ul class="popular">
                 <li><a href="fr/longueur/convertir-metre-en-pied/">m→ft</a></li>
                 <li><a href="fr/longueur/convertir-centimetre-en-pouce/">cm→in</a></li>
-                <li>kg→lb</li>
-                <li>°C→°F</li>
-                <li>L→gal</li>
-                <li>km/h→mph</li>
-                <li>s→min</li>
-                <li>J→kWh</li>
-                <li>Pa→bar</li>
-                <li>Mo→Go</li>
+                <li><a href="fr/masse/convertir-kilogramme-en-livre/">kg→lb</a></li>
+                <li><a href="fr/temperature/convertir-degre-celsius-en-degre-fahrenheit/">°C→°F</a></li>
+                <li><a href="fr/volume/convertir-litre-en-gallon/">L→gal</a></li>
+                <li><a href="fr/vitesse/convertir-kilometre-par-heure-en-mile-par-heure/">km/h→mph</a></li>
+                <li><a href="fr/temps/convertir-seconde-en-minute/">s→min</a></li>
+                <li><a href="fr/energie/convertir-joule-en-kilowatt-heure/">J→kWh</a></li>
+                <li><a href="fr/pression/convertir-pascal-en-bar/">Pa→bar</a></li>
+                <li><a href="fr/donnees/convertir-megaoctet-en-gigaoctet/">Mo→Go</a></li>
             </ul>
         </section>
         <section>


### PR DESCRIPTION
## Summary
- Convert text-only popular conversions into links to individual conversion pages.
- Add placeholder HTML pages for mass, temperature, volume, speed, time, energy, pressure, and data conversions.

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403, unable to install npm)*

------
https://chatgpt.com/codex/tasks/task_e_68c187d20f148329bc73b1d92e0e23df