### PR TITLE
Use shared stylesheet for converters

### DIFF
--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -9,7 +9,7 @@
   <meta property="og:title" content="Tous les convertisseurs d’unités | MesureConvert" />
   <meta property="og:description" content="Accédez aux convertisseurs par catégorie. Longueur, masse, température, etc." />
   <meta property="og:url" content="/convertisseurs/" />
-  <link rel="stylesheet" href="/style.css" />
+  <link rel="stylesheet" href="/style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/convertisseurs/masse/index.html
+++ b/convertisseurs/masse/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Convertisseurs de masse</title>
   <meta name="description" content="Outils pour convertir les unités de masse.">
+  <link rel="stylesheet" href="/style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Conversion kilogrammes en grammes</title>
   <meta name="description" content="Convertir des kilogrammes en grammes avec précision.">
+  <link rel="stylesheet" href="/style.css">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
## Summary
- include `/style.css` in all converter HTML pages
- ensure category and kg-to-g converters load the same styling as homepage

## Testing
- `python3 -m http.server 8000`
- `curl -s http://localhost:8000/index.html | rg '<link rel="stylesheet"'`
- `curl -s http://localhost:8000/convertisseurs/index.html | rg '<link rel="stylesheet"'`
- `curl -s http://localhost:8000/convertisseurs/masse/index.html | rg '<link rel="stylesheet"'`
- `curl -s http://localhost:8000/convertisseurs/masse/kg-vers-g.html | rg '<link rel="stylesheet"'`


------
https://chatgpt.com/codex/tasks/task_e_68c187ccac4883299cfdb3fc96f42a13