### PR TITLE
refactor: centralize form styles and add stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
+++ b/ar/alhararah/tahwil-darajah-mawiyah-ila-fahrenhayt/index.html
@@ -55,14 +55,14 @@
       <h2>أداة التحويل</h2>
       <form>
         <label for="from">من</label>
-        <input id="from" placeholder="درجة مئوية" aria-label="من" />
+        <input id="from" placeholder="درجة مئوية" aria-label="من" class="input" />
         <label for="to">إلى</label>
-        <input id="to" placeholder="فهرنهايت" aria-label="إلى" />
+        <input id="to" placeholder="فهرنهايت" aria-label="إلى" class="input" />
         <label for="value">القيمة</label>
-        <input id="value" placeholder="مثال: ١٫٥" aria-label="القيمة" />
+        <input id="value" placeholder="مثال: ١٫٥" aria-label="القيمة" class="input" />
         <label for="precision">الدقة</label>
-        <input id="precision" placeholder="مثال: ٤" aria-label="الدقة" />
-        <button type="button">تحويل</button>
+        <input id="precision" placeholder="مثال: ٤" aria-label="الدقة" class="input" />
+        <button type="button" class="btn">تحويل</button>
       </form>
       <div class="errors">
         <p>هذا الحقل مطلوب.</p>

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Conversion kilogrammes en grammes</title>
   <meta name="description" content="Convertir des kilogrammes en grammes avec précision.">
+  <link rel="stylesheet" href="/style.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -38,8 +39,8 @@
   <h1>Conversion kilogrammes en grammes</h1>
   <form id="form-convert">
     <label for="valeur">Valeur en kilogrammes</label>
-    <input id="valeur" name="valeur" type="number" min="0" style="min-width:44px;min-height:44px;">
-    <button type="submit" style="min-width:44px;min-height:44px;">Convertir</button>
+    <input id="valeur" name="valeur" type="number" min="0" class="input">
+    <button type="submit" class="btn">Convertir</button>
   </form>
   <div id="badge-precision">BadgePrecision</div>
   <div id="carte-formule">
@@ -53,7 +54,7 @@
       <li>2 kg = 2&nbsp;000 g</li>
     </ul>
   </div>
-  <div id="export-resultats"><button style="min-width:44px;min-height:44px;">Exporter</button></div>
+  <div id="export-resultats"><button class="btn">Exporter</button></div>
   <div id="alerte-erreur" role="alert" hidden>Valeur invalide</div>
   <section id="faq-locale">
     <h2>FAQ</h2>

--- a/en/length/convert-meter-to-foot/index.html
+++ b/en/length/convert-meter-to-foot/index.html
@@ -57,14 +57,14 @@
       <h2>Converter</h2>
       <form>
         <label for="from">From</label>
-        <input id="from" placeholder="meter" aria-label="From" />
+        <input id="from" placeholder="meter" aria-label="From" class="input" />
         <label for="to">To</label>
-        <input id="to" placeholder="foot" aria-label="To" />
+        <input id="to" placeholder="foot" aria-label="To" class="input" />
         <label for="value">Value</label>
-        <input id="value" placeholder="e.g. 1.5" aria-label="Value" />
+        <input id="value" placeholder="e.g. 1.5" aria-label="Value" class="input" />
         <label for="precision">Precision</label>
-        <input id="precision" placeholder="e.g. 4" aria-label="Precision" />
-        <button type="button">Convert</button>
+        <input id="precision" placeholder="e.g. 4" aria-label="Precision" class="input" />
+        <button type="button" class="btn">Convert</button>
       </form>
       <div class="errors">
         <p>This field is required.</p>

--- a/fr/longueur/convertir-centimetre-en-pouce/index.html
+++ b/fr/longueur/convertir-centimetre-en-pouce/index.html
@@ -54,14 +54,14 @@
       <h2>Convertisseur</h2>
       <form>
         <label for="from">De</label>
-        <input id="from" placeholder="centimètre" aria-label="De" />
+        <input id="from" placeholder="centimètre" aria-label="De" class="input" />
         <label for="to">Vers</label>
-        <input id="to" placeholder="pouce" aria-label="Vers" />
+        <input id="to" placeholder="pouce" aria-label="Vers" class="input" />
         <label for="value">Valeur</label>
-        <input id="value" placeholder="ex : 12,5" aria-label="Valeur" />
+        <input id="value" placeholder="ex : 12,5" aria-label="Valeur" class="input" />
         <label for="precision">Précision</label>
-        <input id="precision" placeholder="ex : 4" aria-label="Précision" />
-        <button type="button">Convertir</button>
+        <input id="precision" placeholder="ex : 4" aria-label="Précision" class="input" />
+        <button type="button" class="btn">Convertir</button>
       </form>
       <div class="errors">
         <p>Entrez une valeur.</p>

--- a/fr/longueur/convertir-metre-en-pied/index.html
+++ b/fr/longueur/convertir-metre-en-pied/index.html
@@ -57,14 +57,14 @@
       <h2>Convertisseur</h2>
       <form>
         <label for="from">De</label>
-        <input id="from" placeholder="mètre" aria-label="De" />
+        <input id="from" placeholder="mètre" aria-label="De" class="input" />
         <label for="to">Vers</label>
-        <input id="to" placeholder="pied" aria-label="Vers" />
+        <input id="to" placeholder="pied" aria-label="Vers" class="input" />
         <label for="value">Valeur</label>
-        <input id="value" placeholder="ex : 1,5" aria-label="Valeur" />
+        <input id="value" placeholder="ex : 1,5" aria-label="Valeur" class="input" />
         <label for="precision">Précision</label>
-        <input id="precision" placeholder="ex : 4" aria-label="Précision" />
-        <button type="button">Convertir</button>
+        <input id="precision" placeholder="ex : 4" aria-label="Précision" class="input" />
+        <button type="button" class="btn">Convertir</button>
       </form>
       <div class="errors">
         <p>Ce champ est requis.</p>

--- a/hi/lambai/mitar-se-phut-badalna/index.html
+++ b/hi/lambai/mitar-se-phut-badalna/index.html
@@ -57,14 +57,14 @@
       <h2>कनवर्टर</h2>
       <form>
         <label for="from">से</label>
-        <input id="from" placeholder="मीटर" aria-label="से" />
+        <input id="from" placeholder="मीटर" aria-label="से" class="input" />
         <label for="to">तक</label>
-        <input id="to" placeholder="फ़ुट" aria-label="तक" />
+        <input id="to" placeholder="फ़ुट" aria-label="तक" class="input" />
         <label for="value">मान</label>
-        <input id="value" placeholder="उदा. 1.5" aria-label="मान" />
+        <input id="value" placeholder="उदा. 1.5" aria-label="मान" class="input" />
         <label for="precision">सटीकता</label>
-        <input id="precision" placeholder="उदा. 4" aria-label="सटीकता" />
-        <button type="button">बदलें</button>
+        <input id="precision" placeholder="उदा. 4" aria-label="सटीकता" class="input" />
+        <button type="button" class="btn">बदलें</button>
       </form>
       <div class="errors">
         <p>यह फ़ील्ड आवश्यक है।</p>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
             </div>
             <div class="row">
                 <label for="from-value">Valeur</label>
-                <input type="number" id="from-value" value="0" />
+                <input type="number" id="from-value" value="0" class="input" />
             </div>
             <div class="row">
                 <label for="from-unit">De</label>
@@ -57,10 +57,10 @@
             </div>
             <div class="row">
                 <label for="precision">Précision</label>
-                <input type="number" id="precision" min="0" max="6" value="4" />
+                <input type="number" id="precision" min="0" max="6" value="4" class="input" />
             </div>
             <div class="row">
-                <button id="convert-btn">Convertir</button>
+                <button id="convert-btn" class="btn">Convertir</button>
             </div>
             <div class="row result">
                 <span id="result" aria-live="polite">0</span>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "site",
+  "version": "1.0.0",
+  "description": "Un site de conversion de mesures avec une esthétique minimaliste inspirée d'Apple.",
+  "main": "script.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "lint:css": "stylelint '**/*.css'"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "stylelint": "^16.0.0",
+    "stylelint-config-standard": "^36.0.0"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -119,3 +119,26 @@ footer nav a {
 .popular li {
     margin-bottom: 0.5rem;
 }
+
+.btn,
+.input {
+    min-width: 44px;
+    min-height: 44px;
+}
+
+.btn {
+    padding: 0.5rem;
+    border: 1px solid #d2d2d7;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    background: #007acc;
+    color: #fff;
+    cursor: pointer;
+}
+
+.input {
+    padding: 0.5rem;
+    border: 1px solid #d2d2d7;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+}


### PR DESCRIPTION
## Summary
- remove inline form styles in favor of reusable `.btn` and `.input` classes
- apply shared button and input classes across converter pages
- add stylelint configuration and npm script for CSS linting

## Testing
- `npm install --save-dev stylelint stylelint-config-standard` *(fails: 403 Forbidden - GET https://registry.npmjs.org/stylelint)*
- `npm run lint:css` *(fails: stylelint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d9f198c08329bed86591a4aa2ede