### PR TITLE
Add basic i18n support

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,59 +17,59 @@
         <p class="site-title"><a href="index.html">MesureConvert</a></p>
     </header>
     <main>
-        <h1>Convertisseurs d’unités fiables, instantanés.</h1>
-        <p>Entrez une valeur, choisissez vos unités, obtenez le résultat et la formule. Sans inscription.</p>
+        <h1 data-i18n="headline"></h1>
+        <p data-i18n="description"></p>
         <div class="converter">
             <div class="row">
-                <label for="category">Catégorie</label>
+                <label for="category" data-i18n="labels.category"></label>
                 <select id="category">
-                    <option value="length">Longueur</option>
-                    <option value="weight">Masse</option>
-                    <option value="temperature">Température</option>
-                    <option value="area">Aire</option>
-                    <option value="volume">Volume</option>
-                    <option value="time">Temps</option>
-                    <option value="frequency">Fréquence</option>
-                    <option value="speed">Vitesse</option>
-                    <option value="acceleration">Accélération</option>
-                    <option value="force">Force</option>
-                    <option value="pressure">Pression</option>
-                    <option value="energy">Énergie</option>
-                    <option value="power">Puissance</option>
-                    <option value="density">Densité</option>
-                    <option value="flow">Débit</option>
-                    <option value="torque">Couple</option>
-                    <option value="angle">Angle</option>
-                    <option value="data">Données</option>
+                    <option value="length" data-i18n="categories.length"></option>
+                    <option value="weight" data-i18n="categories.weight"></option>
+                    <option value="temperature" data-i18n="categories.temperature"></option>
+                    <option value="area" data-i18n="categories.area"></option>
+                    <option value="volume" data-i18n="categories.volume"></option>
+                    <option value="time" data-i18n="categories.time"></option>
+                    <option value="frequency" data-i18n="categories.frequency"></option>
+                    <option value="speed" data-i18n="categories.speed"></option>
+                    <option value="acceleration" data-i18n="categories.acceleration"></option>
+                    <option value="force" data-i18n="categories.force"></option>
+                    <option value="pressure" data-i18n="categories.pressure"></option>
+                    <option value="energy" data-i18n="categories.energy"></option>
+                    <option value="power" data-i18n="categories.power"></option>
+                    <option value="density" data-i18n="categories.density"></option>
+                    <option value="flow" data-i18n="categories.flow"></option>
+                    <option value="torque" data-i18n="categories.torque"></option>
+                    <option value="angle" data-i18n="categories.angle"></option>
+                    <option value="data" data-i18n="categories.data"></option>
                 </select>
             </div>
             <div class="row">
-                <label for="from-value">Valeur</label>
+                <label for="from-value" data-i18n="labels.value"></label>
                 <input type="number" id="from-value" value="0" />
             </div>
             <div class="row">
-                <label for="from-unit">De</label>
+                <label for="from-unit" data-i18n="labels.from"></label>
                 <select id="from-unit"></select>
             </div>
             <div class="row">
-                <label for="to-unit">À</label>
+                <label for="to-unit" data-i18n="labels.to"></label>
                 <select id="to-unit"></select>
             </div>
             <div class="row">
-                <label for="precision">Précision</label>
+                <label for="precision" data-i18n="labels.precision"></label>
                 <input type="number" id="precision" min="0" max="6" value="4" />
             </div>
             <div class="row">
-                <button id="convert-btn">Convertir</button>
+                <button id="convert-btn" data-i18n="labels.convert"></button>
             </div>
             <div class="row result">
                 <span id="result" aria-live="polite">0</span>
             </div>
             <div class="row">
-                <span id="precision-badge">Précision: 4 décimales</span>
+                <span id="precision-badge"></span>
             </div>
         </div>
-        <p><a class="cta" href="convertisseurs/index.html">Ouvrir le convertisseur</a></p>
+        <p><a class="cta" href="convertisseurs/index.html" data-i18n="buttons.openConverter"></a></p>
         <section>
             <h2>Convertisseurs par catégorie</h2>
             <ul class="categories">
@@ -128,6 +128,7 @@
             <a href="sitemap.html">Plan du site</a>
         </nav>
     </footer>
-    <script src="script.js"></script>
+    <script src="js/i18n.js"></script>
+      <script src="script.js"></script>
 </body>
 </html>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,43 @@
+let translations = {};
+
+function t(key, vars = {}) {
+  const parts = key.split('.');
+  let value = translations;
+  for (const p of parts) {
+    value = value ? value[p] : undefined;
+  }
+  if (typeof value !== 'string') {
+    return key;
+  }
+  return value.replace(/\{(\w+)\}/g, (_, k) => (k in vars ? vars[k] : ''));
+}
+
+async function loadTranslations(lang) {
+  const res = await fetch(`/js/i18n/${lang}.json`);
+  if (!res.ok) throw new Error('missing lang');
+  translations = await res.json();
+}
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    el.textContent = t(key);
+  });
+}
+
+async function initI18n() {
+  const pathLang = location.pathname.split('/')[1];
+  const htmlLang = document.documentElement.lang;
+  let lang = pathLang || htmlLang || 'en';
+  try {
+    await loadTranslations(lang);
+  } catch (e) {
+    if (lang !== 'en') {
+      await loadTranslations('en');
+    }
+  }
+  applyTranslations();
+}
+
+window.t = t;
+window.initI18n = initI18n;

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -1,0 +1,144 @@
+{
+  "headline": "Fast, reliable unit converters.",
+  "description": "Enter a value, pick your units, get the result and the formula. No sign-up.",
+  "labels": {
+    "category": "Category",
+    "value": "Value",
+    "from": "From",
+    "to": "To",
+    "precision": "Precision",
+    "convert": "Convert"
+  },
+  "messages": {
+    "precisionBadge": "Precision: {decimals} decimals",
+    "conversionImpossible": "Conversion failed"
+  },
+  "buttons": {
+    "openConverter": "Open converter"
+  },
+  "categories": {
+    "length": "Length",
+    "weight": "Mass",
+    "temperature": "Temperature",
+    "area": "Area",
+    "volume": "Volume",
+    "time": "Time",
+    "frequency": "Frequency",
+    "speed": "Speed",
+    "acceleration": "Acceleration",
+    "force": "Force",
+    "pressure": "Pressure",
+    "energy": "Energy",
+    "power": "Power",
+    "density": "Density",
+    "flow": "Flow",
+    "torque": "Torque",
+    "angle": "Angle",
+    "data": "Data"
+  },
+  "units": {
+    "length": {
+      "m": "Meter",
+      "cm": "Centimeter",
+      "mm": "Millimeter",
+      "km": "Kilometer",
+      "in": "Inch",
+      "ft": "Foot",
+      "mi": "Mile"
+    },
+    "weight": {
+      "kg": "Kilogram",
+      "g": "Gram",
+      "t": "Tonne",
+      "lb": "Pound",
+      "oz": "Ounce"
+    },
+    "area": {
+      "m2": "Square meter",
+      "cm2": "Square centimeter",
+      "ha": "Hectare",
+      "acre": "Acre"
+    },
+    "volume": {
+      "L": "Liter",
+      "m3": "Cubic meter",
+      "gal": "Gallon (US)"
+    },
+    "time": {
+      "s": "Second",
+      "min": "Minute",
+      "h": "Hour"
+    },
+    "frequency": {
+      "Hz": "Hertz",
+      "rpm": "RPM",
+      "rad_s": "Rad/s"
+    },
+    "speed": {
+      "m_s": "m/s",
+      "km_h": "km/h",
+      "mph": "mph"
+    },
+    "acceleration": {
+      "m_s2": "m/s²",
+      "g": "g"
+    },
+    "force": {
+      "N": "Newton",
+      "lbf": "Pound-force",
+      "kgf": "Kilogram-force"
+    },
+    "pressure": {
+      "Pa": "Pascal",
+      "bar": "Bar",
+      "atm": "Atmosphere",
+      "psi": "Psi"
+    },
+    "energy": {
+      "J": "Joule",
+      "kJ": "Kilojoule",
+      "MJ": "Megajoule",
+      "Wh": "Watt-hour",
+      "kWh": "Kilowatt-hour",
+      "cal": "Calorie (th)",
+      "BTU": "BTU (IT)"
+    },
+    "power": {
+      "W": "Watt",
+      "kW": "Kilowatt",
+      "hp": "Horsepower"
+    },
+    "density": {
+      "kg_m3": "kg/m³",
+      "g_cm3": "g/cm³"
+    },
+    "flow": {
+      "m3_s": "m³/s",
+      "L_min": "L/min",
+      "L_s": "L/s",
+      "m3_h": "m³/h"
+    },
+    "torque": {
+      "Nm": "N·m",
+      "lbf_ft": "lbf·ft"
+    },
+    "angle": {
+      "rad": "Radian",
+      "deg": "Degree"
+    },
+    "data": {
+      "B": "Byte",
+      "KB": "Kilobyte",
+      "MB": "Megabyte",
+      "GB": "Gigabyte",
+      "KiB": "Kibibyte",
+      "MiB": "Mebibyte",
+      "GiB": "Gibibyte"
+    },
+    "temperature": {
+      "c": "Celsius",
+      "f": "Fahrenheit",
+      "k": "Kelvin"
+    }
+  }
+}

--- a/js/i18n/fr.json
+++ b/js/i18n/fr.json
@@ -1,0 +1,144 @@
+{
+  "headline": "Convertisseurs d’unités fiables, instantanés.",
+  "description": "Entrez une valeur, choisissez vos unités, obtenez le résultat et la formule. Sans inscription.",
+  "labels": {
+    "category": "Catégorie",
+    "value": "Valeur",
+    "from": "De",
+    "to": "À",
+    "precision": "Précision",
+    "convert": "Convertir"
+  },
+  "messages": {
+    "precisionBadge": "Précision: {decimals} décimales",
+    "conversionImpossible": "Conversion impossible"
+  },
+  "buttons": {
+    "openConverter": "Ouvrir le convertisseur"
+  },
+  "categories": {
+    "length": "Longueur",
+    "weight": "Masse",
+    "temperature": "Température",
+    "area": "Aire",
+    "volume": "Volume",
+    "time": "Temps",
+    "frequency": "Fréquence",
+    "speed": "Vitesse",
+    "acceleration": "Accélération",
+    "force": "Force",
+    "pressure": "Pression",
+    "energy": "Énergie",
+    "power": "Puissance",
+    "density": "Densité",
+    "flow": "Débit",
+    "torque": "Couple",
+    "angle": "Angle",
+    "data": "Données"
+  },
+  "units": {
+    "length": {
+      "m": "Mètre",
+      "cm": "Centimètre",
+      "mm": "Millimètre",
+      "km": "Kilomètre",
+      "in": "Pouce",
+      "ft": "Pied",
+      "mi": "Mile"
+    },
+    "weight": {
+      "kg": "Kilogramme",
+      "g": "Gramme",
+      "t": "Tonne",
+      "lb": "Livre",
+      "oz": "Once"
+    },
+    "area": {
+      "m2": "Mètre carré",
+      "cm2": "Centimètre carré",
+      "ha": "Hectare",
+      "acre": "Acre"
+    },
+    "volume": {
+      "L": "Litre",
+      "m3": "Mètre cube",
+      "gal": "Gallon (US)"
+    },
+    "time": {
+      "s": "Seconde",
+      "min": "Minute",
+      "h": "Heure"
+    },
+    "frequency": {
+      "Hz": "Hertz",
+      "rpm": "Tours/minute",
+      "rad_s": "Rad/s"
+    },
+    "speed": {
+      "m_s": "m/s",
+      "km_h": "km/h",
+      "mph": "mph"
+    },
+    "acceleration": {
+      "m_s2": "m/s²",
+      "g": "g"
+    },
+    "force": {
+      "N": "Newton",
+      "lbf": "Livre-force",
+      "kgf": "Kilogramme-force"
+    },
+    "pressure": {
+      "Pa": "Pascal",
+      "bar": "Bar",
+      "atm": "Atmosphère",
+      "psi": "Psi"
+    },
+    "energy": {
+      "J": "Joule",
+      "kJ": "Kilojoule",
+      "MJ": "Mégajoule",
+      "Wh": "Watt-heure",
+      "kWh": "Kilowatt-heure",
+      "cal": "Calorie (th)",
+      "BTU": "BTU (IT)"
+    },
+    "power": {
+      "W": "Watt",
+      "kW": "Kilowatt",
+      "hp": "Cheval vapeur"
+    },
+    "density": {
+      "kg_m3": "kg/m³",
+      "g_cm3": "g/cm³"
+    },
+    "flow": {
+      "m3_s": "m³/s",
+      "L_min": "L/min",
+      "L_s": "L/s",
+      "m3_h": "m³/h"
+    },
+    "torque": {
+      "Nm": "N·m",
+      "lbf_ft": "lbf·ft"
+    },
+    "angle": {
+      "rad": "Radian",
+      "deg": "Degré"
+    },
+    "data": {
+      "B": "Octet",
+      "KB": "Kilooctet",
+      "MB": "Mégaoctet",
+      "GB": "Gigaoctet",
+      "KiB": "Kibioctet",
+      "MiB": "Mibioctet",
+      "GiB": "Gibioctet"
+    },
+    "temperature": {
+      "c": "Celsius",
+      "f": "Fahrenheit",
+      "k": "Kelvin"
+    }
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,142 +1,142 @@
 const categories = {
     length: {
         units: {
-            m: { name: 'Mètre', factor: 1 },
-            cm: { name: 'Centimètre', factor: 0.01 },
-            mm: { name: 'Millimètre', factor: 0.001 },
-            km: { name: 'Kilomètre', factor: 1000 },
-            in: { name: 'Pouce', factor: 0.0254 },
-            ft: { name: 'Pied', factor: 0.3048 },
-            mi: { name: 'Mile', factor: 1609.34 }
+            m: { factor: 1 },
+            cm: { factor: 0.01 },
+            mm: { factor: 0.001 },
+            km: { factor: 1000 },
+            in: { factor: 0.0254 },
+            ft: { factor: 0.3048 },
+            mi: { factor: 1609.34 }
         }
     },
     weight: {
         units: {
-            kg: { name: 'Kilogramme', factor: 1 },
-            g: { name: 'Gramme', factor: 0.001 },
-            t: { name: 'Tonne', factor: 1000 },
-            lb: { name: 'Livre', factor: 0.45359237 },
-            oz: { name: 'Once', factor: 0.028349523125 }
+            kg: { factor: 1 },
+            g: { factor: 0.001 },
+            t: { factor: 1000 },
+            lb: { factor: 0.45359237 },
+            oz: { factor: 0.028349523125 }
         }
     },
     area: {
         units: {
-            m2: { name: 'Mètre carré', factor: 1 },
-            cm2: { name: 'Centimètre carré', factor: 0.0001 },
-            ha: { name: 'Hectare', factor: 10000 },
-            acre: { name: 'Acre', factor: 4046.8564224 }
+            m2: { factor: 1 },
+            cm2: { factor: 0.0001 },
+            ha: { factor: 10000 },
+            acre: { factor: 4046.8564224 }
         }
     },
     volume: {
         units: {
-            L: { name: 'Litre', factor: 1 },
-            m3: { name: 'Mètre cube', factor: 1000 },
-            gal: { name: 'Gallon (US)', factor: 3.785411784 }
+            L: { factor: 1 },
+            m3: { factor: 1000 },
+            gal: { factor: 3.785411784 }
         }
     },
     time: {
         units: {
-            s: { name: 'Seconde', factor: 1 },
-            min: { name: 'Minute', factor: 60 },
-            h: { name: 'Heure', factor: 3600 }
+            s: { factor: 1 },
+            min: { factor: 60 },
+            h: { factor: 3600 }
         }
     },
     frequency: {
         units: {
-            Hz: { name: 'Hertz', factor: 1 },
-            rpm: { name: 'Tours/minute', factor: 1 / 60 },
-            rad_s: { name: 'Rad/s', factor: 1 / (2 * Math.PI) }
+            Hz: { factor: 1 },
+            rpm: { factor: 1 / 60 },
+            rad_s: { factor: 1 / (2 * Math.PI) }
         }
     },
     speed: {
         units: {
-            m_s: { name: 'm/s', factor: 1 },
-            km_h: { name: 'km/h', factor: 1000 / 3600 },
-            mph: { name: 'mph', factor: 1609.344 / 3600 }
+            m_s: { factor: 1 },
+            km_h: { factor: 1000 / 3600 },
+            mph: { factor: 1609.344 / 3600 }
         }
     },
     acceleration: {
         units: {
-            m_s2: { name: 'm/s²', factor: 1 },
-            g: { name: 'g', factor: 9.80665 }
+            m_s2: { factor: 1 },
+            g: { factor: 9.80665 }
         }
     },
     force: {
         units: {
-            N: { name: 'Newton', factor: 1 },
-            lbf: { name: 'Livre-force', factor: 4.4482216152605 },
-            kgf: { name: 'Kilogramme-force', factor: 9.80665 }
+            N: { factor: 1 },
+            lbf: { factor: 4.4482216152605 },
+            kgf: { factor: 9.80665 }
         }
     },
     pressure: {
         units: {
-            Pa: { name: 'Pascal', factor: 1 },
-            bar: { name: 'Bar', factor: 100000 },
-            atm: { name: 'Atmosphère', factor: 101325 },
-            psi: { name: 'Psi', factor: 6894.757293168 }
+            Pa: { factor: 1 },
+            bar: { factor: 100000 },
+            atm: { factor: 101325 },
+            psi: { factor: 6894.757293168 }
         }
     },
     energy: {
         units: {
-            J: { name: 'Joule', factor: 1 },
-            kJ: { name: 'Kilojoule', factor: 1000 },
-            MJ: { name: 'Mégajoule', factor: 1000000 },
-            Wh: { name: 'Watt-heure', factor: 3600 },
-            kWh: { name: 'Kilowatt-heure', factor: 3600000 },
-            cal: { name: 'Calorie (th)', factor: 4.184 },
-            BTU: { name: 'BTU (IT)', factor: 1055.056 }
+            J: { factor: 1 },
+            kJ: { factor: 1000 },
+            MJ: { factor: 1000000 },
+            Wh: { factor: 3600 },
+            kWh: { factor: 3600000 },
+            cal: { factor: 4.184 },
+            BTU: { factor: 1055.056 }
         }
     },
     power: {
         units: {
-            W: { name: 'Watt', factor: 1 },
-            kW: { name: 'Kilowatt', factor: 1000 },
-            hp: { name: 'Cheval vapeur', factor: 745.699872 }
+            W: { factor: 1 },
+            kW: { factor: 1000 },
+            hp: { factor: 745.699872 }
         }
     },
     density: {
         units: {
-            kg_m3: { name: 'kg/m³', factor: 1 },
-            g_cm3: { name: 'g/cm³', factor: 1000 }
+            kg_m3: { factor: 1 },
+            g_cm3: { factor: 1000 }
         }
     },
     flow: {
         units: {
-            m3_s: { name: 'm³/s', factor: 1 },
-            L_min: { name: 'L/min', factor: 1 / 60000 },
-            L_s: { name: 'L/s', factor: 0.001 },
-            m3_h: { name: 'm³/h', factor: 1 / 3600 }
+            m3_s: { factor: 1 },
+            L_min: { factor: 1 / 60000 },
+            L_s: { factor: 0.001 },
+            m3_h: { factor: 1 / 3600 }
         }
     },
     torque: {
         units: {
-            Nm: { name: 'N·m', factor: 1 },
-            lbf_ft: { name: 'lbf·ft', factor: 1.3558179483314004 }
+            Nm: { factor: 1 },
+            lbf_ft: { factor: 1.3558179483314004 }
         }
     },
     angle: {
         units: {
-            rad: { name: 'Radian', factor: 1 },
-            deg: { name: 'Degré', factor: Math.PI / 180 }
+            rad: { factor: 1 },
+            deg: { factor: Math.PI / 180 }
         }
     },
     data: {
         units: {
-            byte: { name: 'Octet', factor: 1 },
-            bit: { name: 'Bit', factor: 1 / 8 },
-            kB: { name: 'Kilooctet', factor: 1000 },
-            MB: { name: 'Mégaoctet', factor: 1000000 },
-            GB: { name: 'Gigaoctet', factor: 1000000000 },
-            KiB: { name: 'Kibioctet', factor: 1024 },
-            MiB: { name: 'Mibioctet', factor: Math.pow(1024, 2) },
-            GiB: { name: 'Gibioctet', factor: Math.pow(1024, 3) }
+            byte: { factor: 1 },
+            bit: { factor: 1 / 8 },
+            kB: { factor: 1000 },
+            MB: { factor: 1000000 },
+            GB: { factor: 1000000000 },
+            KiB: { factor: 1024 },
+            MiB: { factor: Math.pow(1024, 2) },
+            GiB: { factor: Math.pow(1024, 3) }
         }
     },
     temperature: {
         units: {
-            c: { name: 'Celsius' },
-            f: { name: 'Fahrenheit' },
-            k: { name: 'Kelvin' }
+            c: {},
+            f: {},
+            k: {}
         }
     }
 };
@@ -152,7 +152,7 @@ const convertBtn = document.getElementById('convert-btn');
 
 function updatePrecisionBadge() {
     const p = parseInt(precisionInput.value, 10) || 0;
-    precisionBadge.textContent = `Précision: ${p} décimales`;
+    precisionBadge.textContent = t('messages.precisionBadge', { decimals: p });
 }
 
 function populateUnits(cat) {
@@ -162,12 +162,12 @@ function populateUnits(cat) {
     for (const key in units) {
         const optionFrom = document.createElement('option');
         optionFrom.value = key;
-        optionFrom.textContent = units[key].name;
+        optionFrom.textContent = t(`units.${cat}.${key}`);
         fromUnit.appendChild(optionFrom);
 
         const optionTo = document.createElement('option');
         optionTo.value = key;
-        optionTo.textContent = units[key].name;
+        optionTo.textContent = t(`units.${cat}.${key}`);
         toUnit.appendChild(optionTo);
     }
     // reset selections to avoid keeping units from previous categories
@@ -197,7 +197,7 @@ function convert() {
     }
 
     if (typeof result === 'undefined' || isNaN(result)) {
-        resultSpan.textContent = 'Conversion impossible';
+        resultSpan.textContent = t('messages.conversionImpossible');
     } else {
         resultSpan.textContent = result.toFixed(precision);
     }
@@ -245,7 +245,8 @@ precisionInput.addEventListener('input', () => {
 });
 convertBtn.addEventListener('click', convert);
 
-// Initialize
-populateUnits(categorySelect.value);
-updatePrecisionBadge();
-convert();
+initI18n().then(() => {
+    populateUnits(categorySelect.value);
+    updatePrecisionBadge();
+    convert();
+});


### PR DESCRIPTION
## Summary
- Add JSON-based translations for French and English
- Implement runtime i18n loader and helper
- Update converter UI to use translation keys

## Testing
- `node --check script.js`
- `node --check js/i18n.js`
- `node -e "const fs=require('fs');const t=JSON.parse(fs.readFileSync('js/i18n/fr.json','utf8'));console.log(t.labels.category)"`


------
https://chatgpt.com/codex/tasks/task_e_68c2d9f302f48329834c3050ef656b74