### PR TITLE
feat: add reusable converter page module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/convertisseurs/masse/kg-vers-g.html
+++ b/convertisseurs/masse/kg-vers-g.html
@@ -62,5 +62,6 @@
       <p>Parce qu'un kilogramme vaut mille grammes.</p>
     </div>
   </section>
+  <script src="/js/pages/converter-page.js" data-from-unit="kg" data-to-unit="g" data-factor="1000"></script>
 </body>
 </html>

--- a/js/pages/converter-page.js
+++ b/js/pages/converter-page.js
@@ -1,0 +1,53 @@
+(function() {
+  function convert(value, factor, offset = 0) {
+    return value * factor + offset;
+  }
+
+  function setup() {
+    var script = document.currentScript;
+    if (!script) {
+      return;
+    }
+    var fromUnit = script.dataset.fromUnit || '';
+    var toUnit = script.dataset.toUnit || '';
+    var factor = parseFloat(script.dataset.factor || '1');
+
+    var form = document.getElementById('form-convert');
+    var input = document.getElementById('valeur');
+    if (!form || !input) {
+      return;
+    }
+
+    var result = document.getElementById('resultat-conversion');
+    if (!result) {
+      result = document.createElement('div');
+      result.id = 'resultat-conversion';
+      form.insertAdjacentElement('afterend', result);
+    }
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      var value = parseFloat(input.value);
+      if (isNaN(value)) {
+        result.textContent = 'Valeur invalide';
+        return;
+      }
+      var res = convert(value, factor);
+      result.textContent = value + ' ' + fromUnit + ' = ' + res + ' ' + toUnit;
+    });
+  }
+
+  if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setup);
+    } else {
+      setup();
+    }
+  }
+
+  if (typeof module !== 'undefined') {
+    module.exports = { convert: convert };
+  } else {
+    window.converterPage = { convert: convert };
+  }
+})();


### PR DESCRIPTION
## Summary
- add `converter-page.js` to handle form-based unit conversions
- load common module in kilogram-to-gram page with unit parameters via `data-*` attributes

## Testing
- `node -e "const { convert } = require('./js/pages/converter-page.js'); console.log(convert(2, 1000));"`
- `npm install jsdom --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d9f44d888329b47aaafe4b217223