### PR TITLE
feat: structure error pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,14 +1,32 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Page non trouvée</title>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>404 - Page non trouvée</h1>
-  <p>La page que vous cherchez n'existe pas.</p>
-  <a href="/">Retour à l'accueil</a>
+  <header>
+    <p class="site-title"><a href="index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <h1>404 - Page non trouvée</h1>
+    <p>La page que vous cherchez n'existe pas.</p>
+    <p><a href="index.html">Retour à l'accueil</a></p>
+  </main>
+  <footer>
+    <nav>
+      <a href="a-propos.html">À propos</a>
+      <a href="contact.html">Contact</a>
+      <a href="politique-de-confidentialite.html">Confidentialité</a>
+      <a href="conditions-generales.html">Conditions</a>
+      <a href="cookies.html">Cookies</a>
+      <a href="accessibilite.html">Accessibilité</a>
+      <a href="securite-des-donnees.html">Sécurité des données</a>
+      <a href="sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>

--- a/500.html
+++ b/500.html
@@ -1,14 +1,32 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Erreur interne du serveur</title>
-  <meta name="robots" content="noindex">
+  <meta name="robots" content="noindex" />
+  <link rel="stylesheet" href="/style.css" />
 </head>
 <body>
-  <h1>500 - Erreur interne du serveur</h1>
-  <p>Une erreur inattendue est survenue.</p>
-  <a href="/">Retour à l'accueil</a>
+  <header>
+    <p class="site-title"><a href="index.html">MesureConvert</a></p>
+  </header>
+  <main>
+    <h1>500 - Erreur interne du serveur</h1>
+    <p>Une erreur inattendue est survenue.</p>
+    <p><a href="index.html">Retour à l'accueil</a></p>
+  </main>
+  <footer>
+    <nav>
+      <a href="a-propos.html">À propos</a>
+      <a href="contact.html">Contact</a>
+      <a href="politique-de-confidentialite.html">Confidentialité</a>
+      <a href="conditions-generales.html">Conditions</a>
+      <a href="cookies.html">Cookies</a>
+      <a href="accessibilite.html">Accessibilité</a>
+      <a href="securite-des-donnees.html">Sécurité des données</a>
+      <a href="sitemap.html">Plan du site</a>
+    </nav>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add consistent header, main and footer to 404 and 500 error pages
- include navigation and home link for easier recovery
- verify error pages keep a logical heading structure

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2da05eb488329b3ce60d82b467c98