### PR TITLE
Add category pages for unit converters

### DIFF
--- a/convertisseurs/aire/index.html
+++ b/convertisseurs/aire/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs d'aire</title>
+  <meta name="description" content="Outils pour convertir les unités d'aire.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Aire"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Aire</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs d'aire</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/donnees/index.html
+++ b/convertisseurs/donnees/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de données</title>
+  <meta name="description" content="Outils pour convertir les unités de données.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Données"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Données</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de données</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/energie/index.html
+++ b/convertisseurs/energie/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs d'énergie</title>
+  <meta name="description" content="Outils pour convertir les unités d'énergie.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Énergie"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Énergie</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs d'énergie</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/index.html
+++ b/convertisseurs/index.html
@@ -31,16 +31,16 @@
     <p>Choisissez une catégorie pour afficher ses conversions.</p>
     <div class="content">
       <ul class="categories">
-        <li>Longueur – mesures de m à ft, km, mi…</li>
+        <li><a href="/convertisseurs/longueur/">Longueur</a> – mesures de m à ft, km, mi…</li>
         <li><a href="/convertisseurs/masse/">Masse</a> – de g à kg, lb, oz…</li>
-        <li>Température – entre °C, °F, K…</li>
-        <li>Volume – litres, gallons, m³…</li>
-        <li>Aire – m², ft², hectares…</li>
-        <li>Vitesse – km/h, mph, m/s…</li>
-        <li>Temps – s, min, h…</li>
-        <li>Énergie – J, kWh, cal…</li>
-        <li>Pression – Pa, bar, psi…</li>
-        <li>Données – Mo, Go, To…</li>
+        <li><a href="/convertisseurs/temperature/">Température</a> – entre °C, °F, K…</li>
+        <li><a href="/convertisseurs/volume/">Volume</a> – litres, gallons, m³…</li>
+        <li><a href="/convertisseurs/aire/">Aire</a> – m², ft², hectares…</li>
+        <li><a href="/convertisseurs/vitesse/">Vitesse</a> – km/h, mph, m/s…</li>
+        <li><a href="/convertisseurs/temps/">Temps</a> – s, min, h…</li>
+        <li><a href="/convertisseurs/energie/">Énergie</a> – J, kWh, cal…</li>
+        <li><a href="/convertisseurs/pression/">Pression</a> – Pa, bar, psi…</li>
+        <li><a href="/convertisseurs/donnees/">Données</a> – Mo, Go, To…</li>
       </ul>
     </div>
     <aside class="sidebar">

--- a/convertisseurs/longueur/index.html
+++ b/convertisseurs/longueur/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de longueur</title>
+  <meta name="description" content="Outils pour convertir les unités de longueur.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Longueur"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Longueur</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de longueur</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/pression/index.html
+++ b/convertisseurs/pression/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de pression</title>
+  <meta name="description" content="Outils pour convertir les unités de pression.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Pression"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Pression</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de pression</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/temperature/index.html
+++ b/convertisseurs/temperature/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de température</title>
+  <meta name="description" content="Outils pour convertir les unités de température.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Température"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Température</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de température</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/temps/index.html
+++ b/convertisseurs/temps/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de temps</title>
+  <meta name="description" content="Outils pour convertir les unités de temps.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Temps"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Temps</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de temps</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/vitesse/index.html
+++ b/convertisseurs/vitesse/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de vitesse</title>
+  <meta name="description" content="Outils pour convertir les unités de vitesse.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Vitesse"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Vitesse</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de vitesse</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/convertisseurs/volume/index.html
+++ b/convertisseurs/volume/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Convertisseurs de volume</title>
+  <meta name="description" content="Outils pour convertir les unités de volume.">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Accueil", "item": "/"},
+      {"@type": "ListItem", "position": 2, "name": "Convertisseurs", "item": "/convertisseurs/"},
+      {"@type": "ListItem", "position": 3, "name": "Volume"}
+    ]
+  }
+  </script>
+</head>
+<body>
+  <nav aria-label="Fil d'Ariane">
+    <ol>
+      <li><a href="/">Accueil</a></li>
+      <li><a href="/convertisseurs/">Convertisseurs</a></li>
+      <li aria-current="page">Volume</li>
+    </ol>
+  </nav>
+  <h1>Convertisseurs de volume</h1>
+  <ul>
+  </ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -73,24 +73,24 @@
         <section>
             <h2>Convertisseurs par catégorie</h2>
             <ul class="categories">
-                <li><a href="convertisseurs/index.html?cat=length">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
-                <li><a href="convertisseurs/index.html?cat=weight">Masse – Conversions entre kg, lb, g, oz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=temperature">Température – Conversions entre °C, °F, K…</a></li>
-                <li><a href="convertisseurs/index.html?cat=area">Aire – Conversions entre m², ft²…</a></li>
-                <li><a href="convertisseurs/index.html?cat=volume">Volume – Conversions entre L, gal, m³…</a></li>
-                <li><a href="convertisseurs/index.html?cat=time">Temps – Conversions entre s, min, h…</a></li>
+                <li><a href="convertisseurs/longueur/">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
+                <li><a href="convertisseurs/masse/">Masse – Conversions entre kg, lb, g, oz…</a></li>
+                <li><a href="convertisseurs/temperature/">Température – Conversions entre °C, °F, K…</a></li>
+                <li><a href="convertisseurs/aire/">Aire – Conversions entre m², ft²…</a></li>
+                <li><a href="convertisseurs/volume/">Volume – Conversions entre L, gal, m³…</a></li>
+                <li><a href="convertisseurs/temps/">Temps – Conversions entre s, min, h…</a></li>
                 <li><a href="convertisseurs/index.html?cat=frequency">Fréquence – Conversions entre Hz, kHz, MHz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=speed">Vitesse – Conversions entre km/h, mph…</a></li>
+                <li><a href="convertisseurs/vitesse/">Vitesse – Conversions entre km/h, mph…</a></li>
                 <li><a href="convertisseurs/index.html?cat=acceleration">Accélération – Conversions entre m/s², g, ft/s²…</a></li>
                 <li><a href="convertisseurs/index.html?cat=force">Force – Conversions entre N, lbf, kgf…</a></li>
-                <li><a href="convertisseurs/index.html?cat=pressure">Pression – Conversions entre Pa, bar…</a></li>
-                <li><a href="convertisseurs/index.html?cat=energy">Énergie – Conversions entre J, kWh…</a></li>
+                <li><a href="convertisseurs/pression/">Pression – Conversions entre Pa, bar…</a></li>
+                <li><a href="convertisseurs/energie/">Énergie – Conversions entre J, kWh…</a></li>
                 <li><a href="convertisseurs/index.html?cat=power">Puissance – Conversions entre W, kW, ch…</a></li>
                 <li><a href="convertisseurs/index.html?cat=density">Densité – Conversions entre kg/m³, g/cm³, lb/ft³…</a></li>
                 <li><a href="convertisseurs/index.html?cat=flow">Débit – Conversions entre m³/s, L/min, gal/min…</a></li>
                 <li><a href="convertisseurs/index.html?cat=torque">Couple – Conversions entre N·m, lb·ft…</a></li>
                 <li><a href="convertisseurs/index.html?cat=angle">Angle – Conversions entre rad, °, grad…</a></li>
-                <li><a href="convertisseurs/index.html?cat=data">Données – Conversions entre Mo, Go…</a></li>
+                <li><a href="convertisseurs/donnees/">Données – Conversions entre Mo, Go…</a></li>
             </ul>
         </section>
         <section>

--- a/sitemap.html
+++ b/sitemap.html
@@ -16,6 +16,16 @@
         <ul>
             <li><a href="index.html">Accueil</a></li>
             <li><a href="convertisseurs/index.html">Convertisseurs</a></li>
+            <li><a href="convertisseurs/longueur/">Longueur</a></li>
+            <li><a href="convertisseurs/masse/">Masse</a></li>
+            <li><a href="convertisseurs/temperature/">Température</a></li>
+            <li><a href="convertisseurs/volume/">Volume</a></li>
+            <li><a href="convertisseurs/aire/">Aire</a></li>
+            <li><a href="convertisseurs/vitesse/">Vitesse</a></li>
+            <li><a href="convertisseurs/temps/">Temps</a></li>
+            <li><a href="convertisseurs/energie/">Énergie</a></li>
+            <li><a href="convertisseurs/pression/">Pression</a></li>
+            <li><a href="convertisseurs/donnees/">Données</a></li>
             <li><a href="a-propos.html">À propos</a></li>
             <li><a href="contact.html">Contact</a></li>
             <li><a href="politique-de-confidentialite.html">Politique de confidentialité</a></li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -19,6 +19,15 @@
   <url><loc>/500.html</loc></url>
   <url><loc>/ar/alhararah/</loc></url>
   <url><loc>/convertisseurs/masse/</loc></url>
+  <url><loc>/convertisseurs/longueur/</loc></url>
+  <url><loc>/convertisseurs/temperature/</loc></url>
+  <url><loc>/convertisseurs/volume/</loc></url>
+  <url><loc>/convertisseurs/aire/</loc></url>
+  <url><loc>/convertisseurs/vitesse/</loc></url>
+  <url><loc>/convertisseurs/temps/</loc></url>
+  <url><loc>/convertisseurs/energie/</loc></url>
+  <url><loc>/convertisseurs/pression/</loc></url>
+  <url><loc>/convertisseurs/donnees/</loc></url>
   <url><loc>/convertisseurs/masse/kg-vers-g.html</loc></url>
   <url><loc>/en/about.html</loc></url>
   <url><loc>/en/accessibility.html</loc></url>


### PR DESCRIPTION
## Summary
- link converter categories to dedicated directories
- add index pages for length, temperature, volume, area, speed, time, energy, pressure, and data
- update sitemap files and site links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2da12e1cc8329a9b165330418277d