### PR TITLE
Support dynamic page language

### DIFF
--- a/build.py
+++ b/build.py
@@ -26,6 +26,7 @@ for page in pages:
     html = html.replace('{{ content }}', content)
     html = html.replace('{{ title }}', page['title'])
     html = html.replace('{{ description }}', page['description'])
+    html = html.replace('{{ lang }}', page.get('lang', 'fr'))
     dest_path = os.path.join(DIST_DIR, page['file'])
     os.makedirs(os.path.dirname(dest_path), exist_ok=True)
     with open(dest_path, 'w', encoding='utf-8') as f:

--- a/pages.json
+++ b/pages.json
@@ -2,46 +2,55 @@
   {
     "file": "index.html",
     "title": "Convertisseurs d’unités précis et rapides | MesureConvert",
-    "description": "Convertissez longueur, masse, température, volume, vitesse, données et plus. Résultats fiables, formules et exemples."
+    "description": "Convertissez longueur, masse, température, volume, vitesse, données et plus. Résultats fiables, formules et exemples.",
+    "lang": "fr"
   },
   {
     "file": "a-propos.html",
     "title": "À propos - Convertisseur Universel",
-    "description": "Découvrez l'objectif et l'équipe derrière Convertisseur Universel."
+    "description": "Découvrez l'objectif et l'équipe derrière Convertisseur Universel.",
+    "lang": "fr"
   },
   {
     "file": "contact.html",
     "title": "Contact - Convertisseur Universel",
-    "description": "Contactez l'équipe de Convertisseur Universel pour toute question ou suggestion."
+    "description": "Contactez l'équipe de Convertisseur Universel pour toute question ou suggestion.",
+    "lang": "fr"
   },
   {
     "file": "conditions-generales.html",
     "title": "Conditions générales - Convertisseur Universel",
-    "description": "Conditions générales d'utilisation du site Convertisseur Universel."
+    "description": "Conditions générales d'utilisation du site Convertisseur Universel.",
+    "lang": "fr"
   },
   {
     "file": "cookies.html",
     "title": "Cookies - Convertisseur Universel",
-    "description": "Informations sur l'utilisation des cookies et la gestion de vos préférences sur Convertisseur Universel."
+    "description": "Informations sur l'utilisation des cookies et la gestion de vos préférences sur Convertisseur Universel.",
+    "lang": "fr"
   },
   {
     "file": "accessibilite.html",
     "title": "Accessibilité - Convertisseur Universel",
-    "description": "Notre engagement pour rendre Convertisseur Universel accessible à tous les utilisateurs."
+    "description": "Notre engagement pour rendre Convertisseur Universel accessible à tous les utilisateurs.",
+    "lang": "fr"
   },
   {
     "file": "politique-de-confidentialite.html",
     "title": "Politique de confidentialité - Convertisseur Universel",
-    "description": "Découvrez comment Convertisseur Universel protège et utilise vos données personnelles."
+    "description": "Découvrez comment Convertisseur Universel protège et utilise vos données personnelles.",
+    "lang": "fr"
   },
   {
     "file": "securite-des-donnees.html",
     "title": "Sécurité des données - Convertisseur Universel",
-    "description": "Mesures de sécurité mises en place pour protéger vos informations sur Convertisseur Universel."
+    "description": "Mesures de sécurité mises en place pour protéger vos informations sur Convertisseur Universel.",
+    "lang": "fr"
   },
   {
     "file": "sitemap.html",
     "title": "Plan du site - Convertisseur Universel",
-    "description": "Plan du site Convertisseur Universel pour accéder rapidement à toutes les pages."
+    "description": "Plan du site Convertisseur Universel pour accéder rapidement à toutes les pages.",
+    "lang": "fr"
   }
 ]

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="{{ lang }}">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- Render layout with a configurable `lang` attribute instead of hard-coded `fr`
- Inject page-specific language values during build
- Add `lang` metadata for all pages

## Testing
- `python build.py`
- `rg '<html lang="[^"]*"' -n dist | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c2df52eb8083298923d31eef9bf823