### PR TITLE
Use relative asset paths

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,9 +27,12 @@ for page in pages:
     html = html.replace('{{ title }}', page['title'])
     html = html.replace('{{ description }}', page['description'])
     dest_path = os.path.join(DIST_DIR, page['file'])
-    os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+    dest_dir = os.path.dirname(dest_path)
+    os.makedirs(dest_dir, exist_ok=True)
     with open(dest_path, 'w', encoding='utf-8') as f:
         f.write(html)
+    for asset in ['style.css', 'script.js']:
+        shutil.copy2(asset, os.path.join(dest_dir, asset))
 
 # copy remaining files/directories
 for item in os.listdir('.'):

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{{ title }}</title>
     <meta name="description" content="{{ description }}" />
-    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="style.css" />
 </head>
 <body>
 {{ header }}
@@ -13,6 +13,6 @@
 {{ content }}
 </main>
 {{ footer }}
-<script src="/script.js"></script>
+<script src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reference CSS and JS via relative paths in the layout template
- ensure build script copies CSS and JS into each page directory

## Testing
- `python build.py`
- `curl -I http://localhost:8000/subdir/index.html`
- `curl -I http://localhost:8000/subdir/style.css`
- `curl -I http://localhost:8000/subdir/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2df54d99c83298d6c376417cfc0f6