### PR TITLE
Load unit categories from JSON

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,6 +13,9 @@ with open(os.path.join(TEMPLATE_DIR, 'layout.html'), encoding='utf-8') as f:
 with open('pages.json', encoding='utf-8') as f:
     pages = json.load(f)
 
+with open(os.path.join('data', 'categories.json'), encoding='utf-8') as f:
+    categories = json.load(f)
+
 if os.path.exists(DIST_DIR):
     shutil.rmtree(DIST_DIR)
 os.makedirs(DIST_DIR, exist_ok=True)
@@ -21,6 +24,18 @@ for page in pages:
     src_path = os.path.join(SRC_DIR, page['file'])
     with open(src_path, encoding='utf-8') as f:
         content = f.read()
+
+    if page['file'] == 'index.html':
+        items = []
+        for key, cat in categories.items():
+            unit_keys = list(cat['units'].keys())
+            examples = ', '.join(unit_keys[:6])
+            items.append(
+                f'<li><a href="convertisseurs/index.html?cat={key}">' 
+                f'{cat["name"]} – Conversions entre {examples}…</a></li>'
+            )
+        cats_html = '\n                '.join(items)
+        content = content.replace('<!-- CATEGORIES_LIST -->', cats_html)
     html = layout.replace('{{ header }}', header)
     html = html.replace('{{ footer }}', footer)
     html = html.replace('{{ content }}', content)

--- a/data/categories.json
+++ b/data/categories.json
@@ -1,0 +1,160 @@
+{
+  "length": {
+    "name": "Longueur",
+    "units": {
+      "m": { "name": "Mètre", "factor": 1 },
+      "cm": { "name": "Centimètre", "factor": 0.01 },
+      "mm": { "name": "Millimètre", "factor": 0.001 },
+      "km": { "name": "Kilomètre", "factor": 1000 },
+      "in": { "name": "Pouce", "factor": 0.0254 },
+      "ft": { "name": "Pied", "factor": 0.3048 },
+      "mi": { "name": "Mile", "factor": 1609.34 }
+    }
+  },
+  "weight": {
+    "name": "Masse",
+    "units": {
+      "kg": { "name": "Kilogramme", "factor": 1 },
+      "g": { "name": "Gramme", "factor": 0.001 },
+      "t": { "name": "Tonne", "factor": 1000 },
+      "lb": { "name": "Livre", "factor": 0.45359237 },
+      "oz": { "name": "Once", "factor": 0.028349523125 }
+    }
+  },
+  "area": {
+    "name": "Aire",
+    "units": {
+      "m2": { "name": "Mètre carré", "factor": 1 },
+      "cm2": { "name": "Centimètre carré", "factor": 0.0001 },
+      "ha": { "name": "Hectare", "factor": 10000 },
+      "acre": { "name": "Acre", "factor": 4046.8564224 }
+    }
+  },
+  "volume": {
+    "name": "Volume",
+    "units": {
+      "L": { "name": "Litre", "factor": 1 },
+      "m3": { "name": "Mètre cube", "factor": 1000 },
+      "gal": { "name": "Gallon (US)", "factor": 3.785411784 }
+    }
+  },
+  "time": {
+    "name": "Temps",
+    "units": {
+      "s": { "name": "Seconde", "factor": 1 },
+      "min": { "name": "Minute", "factor": 60 },
+      "h": { "name": "Heure", "factor": 3600 }
+    }
+  },
+  "frequency": {
+    "name": "Fréquence",
+    "units": {
+      "Hz": { "name": "Hertz", "factor": 1 },
+      "rpm": { "name": "Tours/minute", "factor": 0.016666666666666666 },
+      "rad_s": { "name": "Rad/s", "factor": 0.15915494309189535 }
+    }
+  },
+  "speed": {
+    "name": "Vitesse",
+    "units": {
+      "m_s": { "name": "m/s", "factor": 1 },
+      "km_h": { "name": "km/h", "factor": 0.2777777777777778 },
+      "mph": { "name": "mph", "factor": 0.44704 }
+    }
+  },
+  "acceleration": {
+    "name": "Accélération",
+    "units": {
+      "m_s2": { "name": "m/s²", "factor": 1 },
+      "g": { "name": "g", "factor": 9.80665 }
+    }
+  },
+  "force": {
+    "name": "Force",
+    "units": {
+      "N": { "name": "Newton", "factor": 1 },
+      "lbf": { "name": "Livre-force", "factor": 4.4482216152605 },
+      "kgf": { "name": "Kilogramme-force", "factor": 9.80665 }
+    }
+  },
+  "pressure": {
+    "name": "Pression",
+    "units": {
+      "Pa": { "name": "Pascal", "factor": 1 },
+      "bar": { "name": "Bar", "factor": 100000 },
+      "atm": { "name": "Atmosphère", "factor": 101325 },
+      "psi": { "name": "Psi", "factor": 6894.757293168 }
+    }
+  },
+  "energy": {
+    "name": "Énergie",
+    "units": {
+      "J": { "name": "Joule", "factor": 1 },
+      "kJ": { "name": "Kilojoule", "factor": 1000 },
+      "MJ": { "name": "Mégajoule", "factor": 1000000 },
+      "Wh": { "name": "Watt-heure", "factor": 3600 },
+      "kWh": { "name": "Kilowatt-heure", "factor": 3600000 },
+      "cal": { "name": "Calorie (th)", "factor": 4.184 },
+      "BTU": { "name": "BTU (IT)", "factor": 1055.056 }
+    }
+  },
+  "power": {
+    "name": "Puissance",
+    "units": {
+      "W": { "name": "Watt", "factor": 1 },
+      "kW": { "name": "Kilowatt", "factor": 1000 },
+      "hp": { "name": "Cheval vapeur", "factor": 745.699872 }
+    }
+  },
+  "density": {
+    "name": "Densité",
+    "units": {
+      "kg_m3": { "name": "kg/m³", "factor": 1 },
+      "g_cm3": { "name": "g/cm³", "factor": 1000 }
+    }
+  },
+  "flow": {
+    "name": "Débit",
+    "units": {
+      "m3_s": { "name": "m³/s", "factor": 1 },
+      "L_min": { "name": "L/min", "factor": 0.000016666666666666667 },
+      "L_s": { "name": "L/s", "factor": 0.001 },
+      "m3_h": { "name": "m³/h", "factor": 0.0002777777777777778 }
+    }
+  },
+  "torque": {
+    "name": "Couple",
+    "units": {
+      "Nm": { "name": "N·m", "factor": 1 },
+      "lbf_ft": { "name": "lbf·ft", "factor": 1.3558179483314004 }
+    }
+  },
+  "angle": {
+    "name": "Angle",
+    "units": {
+      "rad": { "name": "Radian", "factor": 1 },
+      "deg": { "name": "Degré", "factor": 0.017453292519943295 }
+    }
+  },
+  "data": {
+    "name": "Données",
+    "units": {
+      "byte": { "name": "Octet", "factor": 1 },
+      "bit": { "name": "Bit", "factor": 0.125 },
+      "kB": { "name": "Kilooctet", "factor": 1000 },
+      "MB": { "name": "Mégaoctet", "factor": 1000000 },
+      "GB": { "name": "Gigaoctet", "factor": 1000000000 },
+      "KiB": { "name": "Kibioctet", "factor": 1024 },
+      "MiB": { "name": "Mibioctet", "factor": 1048576 },
+      "GiB": { "name": "Gibioctet", "factor": 1073741824 }
+    }
+  },
+  "temperature": {
+    "name": "Température",
+    "units": {
+      "c": { "name": "Celsius" },
+      "f": { "name": "Fahrenheit" },
+      "k": { "name": "Kelvin" }
+    }
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,145 +1,4 @@
-const categories = {
-    length: {
-        units: {
-            m: { name: 'Mètre', factor: 1 },
-            cm: { name: 'Centimètre', factor: 0.01 },
-            mm: { name: 'Millimètre', factor: 0.001 },
-            km: { name: 'Kilomètre', factor: 1000 },
-            in: { name: 'Pouce', factor: 0.0254 },
-            ft: { name: 'Pied', factor: 0.3048 },
-            mi: { name: 'Mile', factor: 1609.34 }
-        }
-    },
-    weight: {
-        units: {
-            kg: { name: 'Kilogramme', factor: 1 },
-            g: { name: 'Gramme', factor: 0.001 },
-            t: { name: 'Tonne', factor: 1000 },
-            lb: { name: 'Livre', factor: 0.45359237 },
-            oz: { name: 'Once', factor: 0.028349523125 }
-        }
-    },
-    area: {
-        units: {
-            m2: { name: 'Mètre carré', factor: 1 },
-            cm2: { name: 'Centimètre carré', factor: 0.0001 },
-            ha: { name: 'Hectare', factor: 10000 },
-            acre: { name: 'Acre', factor: 4046.8564224 }
-        }
-    },
-    volume: {
-        units: {
-            L: { name: 'Litre', factor: 1 },
-            m3: { name: 'Mètre cube', factor: 1000 },
-            gal: { name: 'Gallon (US)', factor: 3.785411784 }
-        }
-    },
-    time: {
-        units: {
-            s: { name: 'Seconde', factor: 1 },
-            min: { name: 'Minute', factor: 60 },
-            h: { name: 'Heure', factor: 3600 }
-        }
-    },
-    frequency: {
-        units: {
-            Hz: { name: 'Hertz', factor: 1 },
-            rpm: { name: 'Tours/minute', factor: 1 / 60 },
-            rad_s: { name: 'Rad/s', factor: 1 / (2 * Math.PI) }
-        }
-    },
-    speed: {
-        units: {
-            m_s: { name: 'm/s', factor: 1 },
-            km_h: { name: 'km/h', factor: 1000 / 3600 },
-            mph: { name: 'mph', factor: 1609.344 / 3600 }
-        }
-    },
-    acceleration: {
-        units: {
-            m_s2: { name: 'm/s²', factor: 1 },
-            g: { name: 'g', factor: 9.80665 }
-        }
-    },
-    force: {
-        units: {
-            N: { name: 'Newton', factor: 1 },
-            lbf: { name: 'Livre-force', factor: 4.4482216152605 },
-            kgf: { name: 'Kilogramme-force', factor: 9.80665 }
-        }
-    },
-    pressure: {
-        units: {
-            Pa: { name: 'Pascal', factor: 1 },
-            bar: { name: 'Bar', factor: 100000 },
-            atm: { name: 'Atmosphère', factor: 101325 },
-            psi: { name: 'Psi', factor: 6894.757293168 }
-        }
-    },
-    energy: {
-        units: {
-            J: { name: 'Joule', factor: 1 },
-            kJ: { name: 'Kilojoule', factor: 1000 },
-            MJ: { name: 'Mégajoule', factor: 1000000 },
-            Wh: { name: 'Watt-heure', factor: 3600 },
-            kWh: { name: 'Kilowatt-heure', factor: 3600000 },
-            cal: { name: 'Calorie (th)', factor: 4.184 },
-            BTU: { name: 'BTU (IT)', factor: 1055.056 }
-        }
-    },
-    power: {
-        units: {
-            W: { name: 'Watt', factor: 1 },
-            kW: { name: 'Kilowatt', factor: 1000 },
-            hp: { name: 'Cheval vapeur', factor: 745.699872 }
-        }
-    },
-    density: {
-        units: {
-            kg_m3: { name: 'kg/m³', factor: 1 },
-            g_cm3: { name: 'g/cm³', factor: 1000 }
-        }
-    },
-    flow: {
-        units: {
-            m3_s: { name: 'm³/s', factor: 1 },
-            L_min: { name: 'L/min', factor: 1 / 60000 },
-            L_s: { name: 'L/s', factor: 0.001 },
-            m3_h: { name: 'm³/h', factor: 1 / 3600 }
-        }
-    },
-    torque: {
-        units: {
-            Nm: { name: 'N·m', factor: 1 },
-            lbf_ft: { name: 'lbf·ft', factor: 1.3558179483314004 }
-        }
-    },
-    angle: {
-        units: {
-            rad: { name: 'Radian', factor: 1 },
-            deg: { name: 'Degré', factor: Math.PI / 180 }
-        }
-    },
-    data: {
-        units: {
-            byte: { name: 'Octet', factor: 1 },
-            bit: { name: 'Bit', factor: 1 / 8 },
-            kB: { name: 'Kilooctet', factor: 1000 },
-            MB: { name: 'Mégaoctet', factor: 1000000 },
-            GB: { name: 'Gigaoctet', factor: 1000000000 },
-            KiB: { name: 'Kibioctet', factor: 1024 },
-            MiB: { name: 'Mibioctet', factor: Math.pow(1024, 2) },
-            GiB: { name: 'Gibioctet', factor: Math.pow(1024, 3) }
-        }
-    },
-    temperature: {
-        units: {
-            c: { name: 'Celsius' },
-            f: { name: 'Fahrenheit' },
-            k: { name: 'Kelvin' }
-        }
-    }
-};
+let categories = {};
 
 const categorySelect = document.getElementById('category');
 const fromValue = document.getElementById('from-value');
@@ -150,102 +9,119 @@ const precisionInput = document.getElementById('precision');
 const precisionBadge = document.getElementById('precision-badge');
 const convertBtn = document.getElementById('convert-btn');
 
-function updatePrecisionBadge() {
-    const p = parseInt(precisionInput.value, 10) || 0;
-    precisionBadge.textContent = `Précision: ${p} décimales`;
+if (categorySelect) {
+    function updatePrecisionBadge() {
+        const p = parseInt(precisionInput.value, 10) || 0;
+        precisionBadge.textContent = `Précision: ${p} décimales`;
+    }
+
+    function populateCategorySelect() {
+        categorySelect.innerHTML = '';
+        for (const key in categories) {
+            const option = document.createElement('option');
+            option.value = key;
+            option.textContent = categories[key].name || key;
+            categorySelect.appendChild(option);
+        }
+    }
+
+    function populateUnits(cat) {
+        const units = categories[cat].units;
+        fromUnit.innerHTML = '';
+        toUnit.innerHTML = '';
+        for (const key in units) {
+            const optionFrom = document.createElement('option');
+            optionFrom.value = key;
+            optionFrom.textContent = units[key].name;
+            fromUnit.appendChild(optionFrom);
+
+            const optionTo = document.createElement('option');
+            optionTo.value = key;
+            optionTo.textContent = units[key].name;
+            toUnit.appendChild(optionTo);
+        }
+        fromUnit.selectedIndex = 0;
+        toUnit.selectedIndex = Math.min(1, toUnit.options.length - 1);
+    }
+
+    function convert() {
+        const cat = categorySelect.value;
+        const value = parseFloat(fromValue.value);
+        const from = fromUnit.value;
+        const to = toUnit.value;
+        const precision = parseInt(precisionInput.value, 10) || 0;
+
+        if (isNaN(value)) {
+            resultSpan.textContent = '—';
+            return;
+        }
+
+        let result;
+
+        if (cat === 'temperature') {
+            result = convertTemperature(value, from, to);
+        } else {
+            const base = value * categories[cat].units[from].factor;
+            result = base / categories[cat].units[to].factor;
+        }
+
+        if (typeof result === 'undefined' || isNaN(result)) {
+            resultSpan.textContent = 'Conversion impossible';
+        } else {
+            resultSpan.textContent = result.toFixed(precision);
+        }
+    }
+
+    function convertTemperature(value, from, to) {
+        let celsius;
+        switch (from) {
+            case 'c':
+                celsius = value;
+                break;
+            case 'f':
+                celsius = (value - 32) * 5 / 9;
+                break;
+            case 'k':
+                celsius = value - 273.15;
+                break;
+            default:
+                return NaN;
+        }
+
+        switch (to) {
+            case 'c':
+                return celsius;
+            case 'f':
+                return celsius * 9 / 5 + 32;
+            case 'k':
+                return celsius + 273.15;
+            default:
+                return NaN;
+        }
+    }
+
+    fetch('data/categories.json')
+        .then(response => response.json())
+        .then(data => {
+            categories = data;
+            populateCategorySelect();
+            populateUnits(categorySelect.value);
+            updatePrecisionBadge();
+            convert();
+
+            categorySelect.addEventListener('change', () => {
+                populateUnits(categorySelect.value);
+                convert();
+            });
+
+            fromValue.addEventListener('input', convert);
+            fromUnit.addEventListener('change', convert);
+            toUnit.addEventListener('change', convert);
+            precisionInput.addEventListener('input', () => {
+                updatePrecisionBadge();
+                convert();
+            });
+            convertBtn.addEventListener('click', convert);
+        });
 }
 
-function populateUnits(cat) {
-    const units = categories[cat].units;
-    fromUnit.innerHTML = '';
-    toUnit.innerHTML = '';
-    for (const key in units) {
-        const optionFrom = document.createElement('option');
-        optionFrom.value = key;
-        optionFrom.textContent = units[key].name;
-        fromUnit.appendChild(optionFrom);
-
-        const optionTo = document.createElement('option');
-        optionTo.value = key;
-        optionTo.textContent = units[key].name;
-        toUnit.appendChild(optionTo);
-    }
-    // reset selections to avoid keeping units from previous categories
-    fromUnit.selectedIndex = 0;
-    toUnit.selectedIndex = Math.min(1, toUnit.options.length - 1);
-}
-
-function convert() {
-    const cat = categorySelect.value;
-    const value = parseFloat(fromValue.value);
-    const from = fromUnit.value;
-    const to = toUnit.value;
-    const precision = parseInt(precisionInput.value, 10) || 0;
-
-    if (isNaN(value)) {
-        resultSpan.textContent = '—';
-        return;
-    }
-
-    let result;
-
-    if (cat === 'temperature') {
-        result = convertTemperature(value, from, to);
-    } else {
-        const base = value * categories[cat].units[from].factor;
-        result = base / categories[cat].units[to].factor;
-    }
-
-    if (typeof result === 'undefined' || isNaN(result)) {
-        resultSpan.textContent = 'Conversion impossible';
-    } else {
-        resultSpan.textContent = result.toFixed(precision);
-    }
-}
-
-function convertTemperature(value, from, to) {
-    let celsius;
-    switch (from) {
-        case 'c':
-            celsius = value;
-            break;
-        case 'f':
-            celsius = (value - 32) * 5 / 9;
-            break;
-        case 'k':
-            celsius = value - 273.15;
-            break;
-        default:
-            return NaN;
-    }
-
-    switch (to) {
-        case 'c':
-            return celsius;
-        case 'f':
-            return celsius * 9 / 5 + 32;
-        case 'k':
-            return celsius + 273.15;
-        default:
-            return NaN;
-    }
-}
-
-categorySelect.addEventListener('change', () => {
-    populateUnits(categorySelect.value);
-    convert();
-});
-
-fromValue.addEventListener('input', convert);
-fromUnit.addEventListener('change', convert);
-toUnit.addEventListener('change', convert);
-precisionInput.addEventListener('input', () => {
-    updatePrecisionBadge();
-    convert();
-});
-convertBtn.addEventListener('click', convert);
-
-// Initialize
-populateUnits(categorySelect.value);
-updatePrecisionBadge();
-convert();

--- a/src/index.html
+++ b/src/index.html
@@ -3,26 +3,7 @@
         <div class="converter">
             <div class="row">
                 <label for="category">Catégorie</label>
-                <select id="category">
-                    <option value="length">Longueur</option>
-                    <option value="weight">Masse</option>
-                    <option value="temperature">Température</option>
-                    <option value="area">Aire</option>
-                    <option value="volume">Volume</option>
-                    <option value="time">Temps</option>
-                    <option value="frequency">Fréquence</option>
-                    <option value="speed">Vitesse</option>
-                    <option value="acceleration">Accélération</option>
-                    <option value="force">Force</option>
-                    <option value="pressure">Pression</option>
-                    <option value="energy">Énergie</option>
-                    <option value="power">Puissance</option>
-                    <option value="density">Densité</option>
-                    <option value="flow">Débit</option>
-                    <option value="torque">Couple</option>
-                    <option value="angle">Angle</option>
-                    <option value="data">Données</option>
-                </select>
+                <select id="category"></select>
             </div>
             <div class="row">
                 <label for="from-value">Valeur</label>
@@ -54,24 +35,7 @@
         <section>
             <h2>Convertisseurs par catégorie</h2>
             <ul class="categories">
-                <li><a href="convertisseurs/index.html?cat=length">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
-                <li><a href="convertisseurs/index.html?cat=weight">Masse – Conversions entre kg, lb, g, oz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=temperature">Température – Conversions entre °C, °F, K…</a></li>
-                <li><a href="convertisseurs/index.html?cat=area">Aire – Conversions entre m², ft²…</a></li>
-                <li><a href="convertisseurs/index.html?cat=volume">Volume – Conversions entre L, gal, m³…</a></li>
-                <li><a href="convertisseurs/index.html?cat=time">Temps – Conversions entre s, min, h…</a></li>
-                <li><a href="convertisseurs/index.html?cat=frequency">Fréquence – Conversions entre Hz, kHz, MHz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=speed">Vitesse – Conversions entre km/h, mph…</a></li>
-                <li><a href="convertisseurs/index.html?cat=acceleration">Accélération – Conversions entre m/s², g, ft/s²…</a></li>
-                <li><a href="convertisseurs/index.html?cat=force">Force – Conversions entre N, lbf, kgf…</a></li>
-                <li><a href="convertisseurs/index.html?cat=pressure">Pression – Conversions entre Pa, bar…</a></li>
-                <li><a href="convertisseurs/index.html?cat=energy">Énergie – Conversions entre J, kWh…</a></li>
-                <li><a href="convertisseurs/index.html?cat=power">Puissance – Conversions entre W, kW, ch…</a></li>
-                <li><a href="convertisseurs/index.html?cat=density">Densité – Conversions entre kg/m³, g/cm³, lb/ft³…</a></li>
-                <li><a href="convertisseurs/index.html?cat=flow">Débit – Conversions entre m³/s, L/min, gal/min…</a></li>
-                <li><a href="convertisseurs/index.html?cat=torque">Couple – Conversions entre N·m, lb·ft…</a></li>
-                <li><a href="convertisseurs/index.html?cat=angle">Angle – Conversions entre rad, °, grad…</a></li>
-                <li><a href="convertisseurs/index.html?cat=data">Données – Conversions entre Mo, Go…</a></li>
+                <!-- CATEGORIES_LIST -->
             </ul>
         </section>
         <section>


### PR DESCRIPTION
## Summary
- Move unit category definitions to `data/categories.json`
- Fetch categories at runtime to populate selectors in `script.js`
- Generate index category list from JSON in `build.py`

## Testing
- `python build.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2df5285ac83299c5d93fdd59c9255