### PR TITLE
Skip converter init when required DOM elements are missing

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,105 +1,133 @@
-import '../css/style.css';
-import { convertTemperature } from './temperature.js';
+import "../css/style.css";
+import { convertTemperature } from "./temperature.js";
 
-let categories = {};
+function initializeConverter() {
+  const categorySelect = document.getElementById("category");
+  const fromValue = document.getElementById("from-value");
+  const fromUnit = document.getElementById("from-unit");
+  const toUnit = document.getElementById("to-unit");
+  const resultSpan = document.getElementById("result");
+  const precisionInput = document.getElementById("precision");
+  const precisionBadge = document.getElementById("precision-badge");
+  const form = document.getElementById("converter");
+  const errorMsg = document.getElementById("error");
 
-const categorySelect = document.getElementById('category');
-const fromValue = document.getElementById('from-value');
-const fromUnit = document.getElementById('from-unit');
-const toUnit = document.getElementById('to-unit');
-const resultSpan = document.getElementById('result');
-const precisionInput = document.getElementById('precision');
-const precisionBadge = document.getElementById('precision-badge');
-const form = document.getElementById('converter');
-const errorMsg = document.getElementById('error');
+  const elements = [
+    categorySelect,
+    fromValue,
+    fromUnit,
+    toUnit,
+    resultSpan,
+    precisionInput,
+    precisionBadge,
+    form,
+    errorMsg,
+  ];
 
-function updatePrecisionBadge() {
-  const p = parseInt(precisionInput.value, 10) || 0;
-  precisionBadge.textContent = `Précision: ${p} décimales`;
-}
-
-function populateCategoryOptions() {
-  categorySelect.innerHTML = '';
-  Object.entries(categories).forEach(([key, cat]) => {
-    const opt = document.createElement('option');
-    opt.value = key;
-    opt.textContent = cat.name;
-    categorySelect.appendChild(opt);
-  });
-}
-
-function populateUnits(cat) {
-  const units = categories[cat].units;
-  fromUnit.innerHTML = '';
-  toUnit.innerHTML = '';
-  Object.entries(units).forEach(([key, u]) => {
-    const optionFrom = document.createElement('option');
-    optionFrom.value = key;
-    optionFrom.textContent = u.name;
-    fromUnit.appendChild(optionFrom);
-    const optionTo = document.createElement('option');
-    optionTo.value = key;
-    optionTo.textContent = u.name;
-    toUnit.appendChild(optionTo);
-  });
-  fromUnit.selectedIndex = 0;
-  toUnit.selectedIndex = Math.min(1, toUnit.options.length - 1);
-}
-
-function convert() {
-  const cat = categorySelect.value;
-  const value = parseFloat(fromValue.value);
-  const from = fromUnit.value;
-  const to = toUnit.value;
-  const precision = parseInt(precisionInput.value, 10) || 0;
-
-  if (isNaN(value)) {
-    resultSpan.textContent = '—';
-    errorMsg.hidden = false;
-    fromValue.setAttribute('aria-invalid', 'true');
+  if (elements.some((element) => element === null)) {
     return;
   }
-  errorMsg.hidden = true;
-  fromValue.removeAttribute('aria-invalid');
 
-  let result;
-  if (cat === 'temperature') {
-    result = convertTemperature(value, from, to);
-  } else {
-    const base = value * categories[cat].units[from].factor;
-    result = base / categories[cat].units[to].factor;
+  let categories = {};
+
+  function updatePrecisionBadge() {
+    const precision = parseInt(precisionInput.value, 10) || 0;
+    precisionBadge.textContent = `Précision: ${precision} décimales`;
   }
 
-  if (typeof result === 'undefined' || isNaN(result)) {
-    resultSpan.textContent = 'Conversion impossible';
-  } else {
-    resultSpan.textContent = result.toFixed(precision);
+  function populateCategoryOptions() {
+    categorySelect.innerHTML = "";
+    Object.entries(categories).forEach(([key, category]) => {
+      const option = document.createElement("option");
+      option.value = key;
+      option.textContent = category.name;
+      categorySelect.appendChild(option);
+    });
   }
+
+  function populateUnits(category) {
+    const units = categories[category].units;
+    fromUnit.innerHTML = "";
+    toUnit.innerHTML = "";
+
+    Object.entries(units).forEach(([key, unit]) => {
+      const optionFrom = document.createElement("option");
+      optionFrom.value = key;
+      optionFrom.textContent = unit.name;
+      fromUnit.appendChild(optionFrom);
+
+      const optionTo = document.createElement("option");
+      optionTo.value = key;
+      optionTo.textContent = unit.name;
+      toUnit.appendChild(optionTo);
+    });
+
+    fromUnit.selectedIndex = 0;
+    toUnit.selectedIndex = Math.min(1, toUnit.options.length - 1);
+  }
+
+  function convert() {
+    const category = categorySelect.value;
+    const value = parseFloat(fromValue.value);
+    const from = fromUnit.value;
+    const to = toUnit.value;
+    const precision = parseInt(precisionInput.value, 10) || 0;
+
+    if (isNaN(value)) {
+      resultSpan.textContent = "—";
+      errorMsg.hidden = false;
+      fromValue.setAttribute("aria-invalid", "true");
+      return;
+    }
+
+    errorMsg.hidden = true;
+    fromValue.removeAttribute("aria-invalid");
+
+    let result;
+
+    if (category === "temperature") {
+      result = convertTemperature(value, from, to);
+    } else {
+      const base = value * categories[category].units[from].factor;
+      result = base / categories[category].units[to].factor;
+    }
+
+    if (typeof result === "undefined" || isNaN(result)) {
+      resultSpan.textContent = "Conversion impossible";
+    } else {
+      resultSpan.textContent = result.toFixed(precision);
+    }
+  }
+
+  categorySelect.addEventListener("change", () => {
+    populateUnits(categorySelect.value);
+    convert();
+  });
+
+  fromValue.addEventListener("input", convert);
+  fromUnit.addEventListener("change", convert);
+  toUnit.addEventListener("change", convert);
+
+  precisionInput.addEventListener("input", () => {
+    updatePrecisionBadge();
+    convert();
+  });
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    convert();
+  });
+
+  async function init() {
+    const response = await fetch("/data/units.json");
+    categories = await response.json();
+    populateCategoryOptions();
+    populateUnits(categorySelect.value);
+    updatePrecisionBadge();
+    convert();
+  }
+
+  init();
 }
 
-categorySelect.addEventListener('change', () => {
-  populateUnits(categorySelect.value);
-  convert();
-});
-fromValue.addEventListener('input', convert);
-fromUnit.addEventListener('change', convert);
-toUnit.addEventListener('change', convert);
-precisionInput.addEventListener('input', () => {
-  updatePrecisionBadge();
-  convert();
-});
-form.addEventListener('submit', (e) => {
-  e.preventDefault();
-  convert();
-});
-
-async function init() {
-  const res = await fetch('/data/units.json');
-  categories = await res.json();
-  populateCategoryOptions();
-  populateUnits(categorySelect.value);
-  updatePrecisionBadge();
-  convert();
-}
-
-init();
+initializeConverter();


### PR DESCRIPTION
## Summary
- wrap the converter setup in an initializer that first checks every required DOM element
- only register event listeners and load units data when the converter markup is present
- preserve existing conversion behaviour while skipping initialization on pages without the converter

## Testing
- npx eslint src/js/script.js
- npx prettier --check src/js/script.js
- python -m http.server 4173 --directory dist (manual verification of index.html and accessibilite.html with Playwright)


------
https://chatgpt.com/codex/tasks/task_e_68d25616dc8883299c8146b4c863df2c