### PR TITLE
Add map page with geolocation support

### DIFF
--- a/pages.json
+++ b/pages.json
@@ -5,6 +5,11 @@
     "description": "Convertissez longueur, masse, température, volume, vitesse, données et plus. Résultats fiables, formules et exemples."
   },
   {
+    "file": "map.html",
+    "title": "Carte interactive et géolocalisation | MesureConvert",
+    "description": "Activez la géolocalisation pour centrer une carte OpenStreetMap sur votre position depuis MesureConvert."
+  },
+  {
     "file": "a-propos.html",
     "title": "À propos - MesureConvert",
     "description": "Découvrez l'objectif et l'équipe derrière MesureConvert."

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,146 +1,200 @@
 body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-    background: linear-gradient(#f5f5f7, #ffffff);
-    color: #1d1d1f;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  background: linear-gradient(#f5f5f7, #ffffff);
+  color: #1d1d1f;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 header {
-    padding: 2rem 0;
-    text-align: center;
+  padding: 2rem 0;
+  text-align: center;
 }
 
 h1 {
-    font-weight: 600;
-    margin: 0;
+  font-weight: 600;
+  margin: 0;
 }
 
 main {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 .converter {
-    background: #ffffff;
-    padding: 2rem;
-    border-radius: 1rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    max-width: 400px;
-    width: 100%;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-width: 400px;
+  width: 100%;
 }
 
 .row {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
 }
 
 .row label {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .row input,
 .row select {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
 }
 
 .row button {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    background: #007acc;
-    color: #fff;
-    cursor: pointer;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  background: #007acc;
+  color: #fff;
+  cursor: pointer;
 }
 
 .result {
-    text-align: center;
-    font-size: 2rem;
-    font-weight: 600;
-    margin-top: 1rem;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 600;
+  margin-top: 1rem;
 }
 
 #precision-badge {
-    display: inline-block;
-    background: #e5e5ea;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
+  display: inline-block;
+  background: #e5e5ea;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
 }
 .site-title {
-    margin: 0;
-    font-weight: 600;
-    text-align: center;
+  margin: 0;
+  font-weight: 600;
+  text-align: center;
 }
 
 .site-title a {
-    color: inherit;
-    text-decoration: none;
+  color: inherit;
+  text-decoration: none;
 }
 
 footer {
-    background: #f5f5f7;
-    padding: 1rem;
-    text-align: center;
+  background: #f5f5f7;
+  padding: 1rem;
+  text-align: center;
 }
 
 footer nav a {
-    margin: 0 0.5rem;
-    color: inherit;
-    text-decoration: none;
+  margin: 0 0.5rem;
+  color: inherit;
+  text-decoration: none;
 }
 
 .cta {
-    display: inline-block;
-    margin-top: 1rem;
-    padding: 0.75rem 1.25rem;
-    background: #007acc;
-    color: #fff;
-    text-decoration: none;
-    border-radius: 0.5rem;
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: #007acc;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 0.5rem;
 }
 
 .categories,
 .popular {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
 .categories li,
 .popular li {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 .input {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    min-width: 44px;
-    min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .btn {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    background: #007acc;
-    color: #fff;
-    cursor: pointer;
-    min-width: 44px;
-    min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  background: #007acc;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .error {
-    color: #b00020;
-    margin-top: 0.5rem;
+  color: #b00020;
+  margin-top: 0.5rem;
+}
+
+.map-section {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  max-width: 960px;
+  width: 100%;
+}
+
+.map-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.map-status {
+  margin: 0;
+}
+
+.map-container {
+  margin-top: 1.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 1rem;
+  overflow: hidden;
+  min-height: 320px;
+  background: #e5e5ea;
+}
+
+#map-frame {
+  width: 100%;
+  height: 400px;
+  border: 0;
+  display: block;
+}
+
+.map-caption {
+  margin-top: 1rem;
+  font-size: 0.875rem;
+  color: #6e6e73;
+}
+
+@media (min-width: 600px) {
+  .map-actions {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .map-actions .btn {
+    width: auto;
+  }
 }

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -1,0 +1,182 @@
+const DEFAULT_LOCATION = { lat: 48.8566, lng: 2.3522 };
+const MAP_DELTA = 0.02;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatLatitude(value) {
+  return clamp(value, -90, 90).toFixed(6);
+}
+
+function formatLongitude(value) {
+  return clamp(value, -180, 180).toFixed(6);
+}
+
+function buildMapUrl({ lat, lng }) {
+  const latClamped = clamp(lat, -90, 90);
+  const lngClamped = clamp(lng, -180, 180);
+  const delta = MAP_DELTA;
+
+  const left = formatLongitude(lngClamped - delta);
+  const right = formatLongitude(lngClamped + delta);
+  const bottom = formatLatitude(latClamped - delta);
+  const top = formatLatitude(latClamped + delta);
+
+  const bbox = `${left}%2C${bottom}%2C${right}%2C${top}`;
+  const markerLat = formatLatitude(latClamped);
+  const markerLng = formatLongitude(lngClamped);
+  const marker = `${markerLat}%2C${markerLng}`;
+
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${marker}`;
+}
+
+function updateMap(frame, container, coords) {
+  frame.src = buildMapUrl(coords);
+  const latText = clamp(coords.lat, -90, 90).toFixed(4);
+  const lngText = clamp(coords.lng, -180, 180).toFixed(4);
+  container.setAttribute(
+    "aria-label",
+    `Carte centrée sur les coordonnées ${latText}°, ${lngText}°`,
+  );
+}
+
+export function initializeMapPage() {
+  const frame = document.getElementById("map-frame");
+  const button = document.getElementById("geolocate-button");
+  const status = document.getElementById("map-status");
+  const errorElement = document.getElementById("map-error");
+  const container = document.getElementById("map-container");
+
+  if (!frame || !button || !status || !errorElement || !container) {
+    return;
+  }
+
+  const clearError = () => {
+    errorElement.hidden = true;
+    errorElement.textContent = "";
+  };
+
+  const setError = (message) => {
+    errorElement.textContent = message;
+    errorElement.hidden = false;
+    status.textContent = "";
+  };
+
+  const setStatus = (message) => {
+    status.textContent = message;
+  };
+
+  const finalize = () => {
+    button.disabled = false;
+    button.removeAttribute("aria-busy");
+  };
+
+  const finishWithError = (message) => {
+    setError(message);
+    finalize();
+  };
+
+  const handleFailure = (error) => {
+    let message = "Impossible de récupérer votre position pour le moment.";
+
+    if (error) {
+      if (error.name === "NotAllowedError" || error.code === 1) {
+        message =
+          "La géolocalisation a été refusée. Autorisez-la dans votre navigateur.";
+      } else if (error.name === "SecurityError") {
+        message =
+          "La géolocalisation nécessite une connexion sécurisée (https).";
+      } else if (error.code === 2) {
+        message =
+          "La position n'est pas disponible. Vérifiez votre connexion ou vos services de localisation.";
+      } else if (error.code === 3) {
+        message =
+          "La requête de géolocalisation a expiré. Réessayez dans un instant.";
+      } else if (
+        typeof error.message === "string" &&
+        error.message.length > 0
+      ) {
+        message = error.message;
+      }
+    }
+
+    finishWithError(message);
+  };
+
+  updateMap(frame, container, DEFAULT_LOCATION);
+  setStatus("Carte centrée sur Paris par défaut.");
+
+  const requestLocation = async () => {
+    clearError();
+    button.disabled = true;
+    button.setAttribute("aria-busy", "true");
+
+    if (!window.isSecureContext) {
+      finishWithError(
+        "La géolocalisation nécessite une connexion sécurisée (https).",
+      );
+      return;
+    }
+
+    if (!("geolocation" in navigator)) {
+      finishWithError(
+        "Votre navigateur ne prend pas en charge la géolocalisation.",
+      );
+      return;
+    }
+
+    if (
+      "permissions" in navigator &&
+      typeof navigator.permissions.query === "function"
+    ) {
+      try {
+        const permissionStatus = await navigator.permissions.query({
+          name: "geolocation",
+        });
+        if (permissionStatus.state === "denied") {
+          finishWithError(
+            "La géolocalisation est désactivée pour ce site. Modifiez les réglages de votre navigateur pour l'activer.",
+          );
+          return;
+        }
+      } catch (permissionError) {
+        console.warn(
+          "Impossible de vérifier l'état de la permission de géolocalisation",
+          permissionError,
+        );
+      }
+    }
+
+    setStatus("Recherche de votre position…");
+
+    const onSuccess = (position) => {
+      const { latitude, longitude } = position.coords;
+      updateMap(frame, container, { lat: latitude, lng: longitude });
+      setStatus(
+        `Carte centrée sur votre position (${latitude.toFixed(4)}°, ${longitude.toFixed(4)}°).`,
+      );
+      finalize();
+    };
+
+    const onError = (error) => {
+      handleFailure(error);
+    };
+
+    try {
+      navigator.geolocation.getCurrentPosition(onSuccess, onError, {
+        enableHighAccuracy: true,
+        timeout: 10000,
+        maximumAge: 0,
+      });
+    } catch (error) {
+      handleFailure(error);
+    }
+  };
+
+  button.addEventListener("click", () => {
+    requestLocation().catch((error) => {
+      handleFailure(error);
+    });
+  });
+}

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,5 +1,6 @@
 import "../css/style.css";
 import { convertTemperature } from "./temperature.js";
+import { initializeMapPage } from "./map.js";
 
 function initializeConverter() {
   const categorySelect = document.getElementById("category");
@@ -131,3 +132,4 @@ function initializeConverter() {
 }
 
 initializeConverter();
+initializeMapPage();

--- a/src/js/temperature.js
+++ b/src/js/temperature.js
@@ -1,24 +1,24 @@
 export function convertTemperature(value, from, to) {
   let celsius;
   switch (from) {
-    case 'c':
+    case "c":
       celsius = value;
       break;
-    case 'f':
-      celsius = (value - 32) * 5 / 9;
+    case "f":
+      celsius = ((value - 32) * 5) / 9;
       break;
-    case 'k':
+    case "k":
       celsius = value - 273.15;
       break;
     default:
       return NaN;
   }
   switch (to) {
-    case 'c':
+    case "c":
       return celsius;
-    case 'f':
-      return celsius * 9 / 5 + 32;
-    case 'k':
+    case "f":
+      return (celsius * 9) / 5 + 32;
+    case "k":
       return celsius + 273.15;
     default:
       return NaN;

--- a/src/map.html
+++ b/src/map.html
@@ -1,0 +1,13 @@
+<h1>Carte interactive</h1>
+        <p>Affichez une carte centrée sur votre position et vérifiez si la géolocalisation est disponible dans votre navigateur.</p>
+        <section class="map-section">
+            <div class="map-actions">
+                <button type="button" id="geolocate-button" class="btn">Activer la géolocalisation</button>
+                <p id="map-status" class="map-status" aria-live="polite"></p>
+                <p id="map-error" class="error" role="alert" hidden></p>
+            </div>
+            <div id="map-container" class="map-container" role="region" aria-live="polite" aria-label="Carte centrée sur votre position">
+                <iframe id="map-frame" title="Carte OpenStreetMap" loading="lazy"></iframe>
+            </div>
+            <p class="map-caption">La carte s’appuie sur OpenStreetMap et n’envoie aucune donnée personnelle vers nos serveurs.</p>
+        </section>


### PR DESCRIPTION
## Summary
- add a dedicated map page with geolocation controls and status messages
- style the map layout and expose the page through pages.json so it is rendered during the build
- encapsulate geolocation handling in a new module imported by the main script to initialise the map safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2af394b7483298183af4bd0eedf81