### PR TITLE
Add category card classes and styling

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,146 +1,236 @@
 body {
-    margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-    background: linear-gradient(#f5f5f7, #ffffff);
-    color: #1d1d1f;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial,
+    sans-serif;
+  background: linear-gradient(#f5f5f7, #ffffff);
+  color: #1d1d1f;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 header {
-    padding: 2rem 0;
-    text-align: center;
+  padding: 2rem 0;
+  text-align: center;
 }
 
 h1 {
-    font-weight: 600;
-    margin: 0;
+  font-weight: 600;
+  margin: 0;
 }
 
 main {
-    flex: 1;
-    display: flex;
-    justify-content: center;
-    align-items: flex-start;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
 }
 
 .converter {
-    background: #ffffff;
-    padding: 2rem;
-    border-radius: 1rem;
-    box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    max-width: 400px;
-    width: 100%;
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-width: 400px;
+  width: 100%;
 }
 
 .row {
-    display: flex;
-    flex-direction: column;
-    margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
 }
 
 .row label {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .row input,
 .row select {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
 }
 
 .row button {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    background: #007acc;
-    color: #fff;
-    cursor: pointer;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  background: #007acc;
+  color: #fff;
+  cursor: pointer;
 }
 
 .result {
-    text-align: center;
-    font-size: 2rem;
-    font-weight: 600;
-    margin-top: 1rem;
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 600;
+  margin-top: 1rem;
 }
 
 #precision-badge {
-    display: inline-block;
-    background: #e5e5ea;
-    padding: 0.25rem 0.5rem;
-    border-radius: 0.5rem;
-    font-size: 0.875rem;
+  display: inline-block;
+  background: #e5e5ea;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
 }
 .site-title {
-    margin: 0;
-    font-weight: 600;
-    text-align: center;
+  margin: 0;
+  font-weight: 600;
+  text-align: center;
 }
 
 .site-title a {
-    color: inherit;
-    text-decoration: none;
+  color: inherit;
+  text-decoration: none;
 }
 
 footer {
-    background: #f5f5f7;
-    padding: 1rem;
-    text-align: center;
+  background: #f5f5f7;
+  padding: 1rem;
+  text-align: center;
 }
 
 footer nav a {
-    margin: 0 0.5rem;
-    color: inherit;
-    text-decoration: none;
+  margin: 0 0.5rem;
+  color: inherit;
+  text-decoration: none;
 }
 
 .cta {
-    display: inline-block;
-    margin-top: 1rem;
-    padding: 0.75rem 1.25rem;
-    background: #007acc;
-    color: #fff;
-    text-decoration: none;
-    border-radius: 0.5rem;
+  display: inline-block;
+  margin-top: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: #007acc;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 0.5rem;
 }
 
 .categories,
 .popular {
-    list-style: none;
-    padding: 0;
+  list-style: none;
+  padding: 0;
 }
 
-.categories li,
+.category-card,
 .popular li {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.category-card {
+  display: block;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  background-color: #ffffff;
+  background-repeat: no-repeat;
+  background-size: cover;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.category-card a {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+}
+
+.category-card--length {
+  background-image: linear-gradient(135deg, #d8ebff 0%, #ffffff 100%);
+}
+
+.category-card--weight {
+  background-image: linear-gradient(135deg, #dff7e5 0%, #ffffff 100%);
+}
+
+.category-card--temperature {
+  background-image: linear-gradient(135deg, #ffe3d6 0%, #ffffff 100%);
+}
+
+.category-card--area {
+  background-image: linear-gradient(135deg, #f2e1ff 0%, #ffffff 100%);
+}
+
+.category-card--volume {
+  background-image: linear-gradient(135deg, #d6f5ff 0%, #ffffff 100%);
+}
+
+.category-card--time {
+  background-image: linear-gradient(135deg, #e6e2ff 0%, #ffffff 100%);
+}
+
+.category-card--frequency {
+  background-image: linear-gradient(135deg, #ffd8f0 0%, #ffffff 100%);
+}
+
+.category-card--speed {
+  background-image: linear-gradient(135deg, #fff2d1 0%, #ffffff 100%);
+}
+
+.category-card--acceleration {
+  background-image: linear-gradient(135deg, #ffd9d9 0%, #ffffff 100%);
+}
+
+.category-card--force {
+  background-image: linear-gradient(135deg, #d9fff2 0%, #ffffff 100%);
+}
+
+.category-card--pressure {
+  background-image: linear-gradient(135deg, #e0f0ff 0%, #ffffff 100%);
+}
+
+.category-card--energy {
+  background-image: linear-gradient(135deg, #ffeed6 0%, #ffffff 100%);
+}
+
+.category-card--power {
+  background-image: linear-gradient(135deg, #ffe0eb 0%, #ffffff 100%);
+}
+
+.category-card--density {
+  background-image: linear-gradient(135deg, #f4e5d8 0%, #ffffff 100%);
+}
+
+.category-card--flow {
+  background-image: linear-gradient(135deg, #d9f3ff 0%, #ffffff 100%);
+}
+
+.category-card--torque {
+  background-image: linear-gradient(135deg, #e5eaf5 0%, #ffffff 100%);
+}
+
+.category-card--angle {
+  background-image: linear-gradient(135deg, #e0f6ff 0%, #ffffff 100%);
+}
+
+.category-card--data {
+  background-image: linear-gradient(135deg, #e0ecff 0%, #ffffff 100%);
 }
 .input {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    min-width: 44px;
-    min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .btn {
-    padding: 0.5rem;
-    border: 1px solid #d2d2d7;
-    border-radius: 0.5rem;
-    font-size: 1rem;
-    background: #007acc;
-    color: #fff;
-    cursor: pointer;
-    min-width: 44px;
-    min-height: 44px;
+  padding: 0.5rem;
+  border: 1px solid #d2d2d7;
+  border-radius: 0.5rem;
+  font-size: 1rem;
+  background: #007acc;
+  color: #fff;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
 }
 
 .error {
-    color: #b00020;
-    margin-top: 0.5rem;
+  color: #b00020;
+  margin-top: 0.5rem;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -38,24 +38,24 @@
         <section>
             <h2>Convertisseurs par catégorie</h2>
             <ul class="categories">
-                <li><a href="convertisseurs/index.html?cat=length">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
-                <li><a href="convertisseurs/index.html?cat=weight">Masse – Conversions entre kg, lb, g, oz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=temperature">Température – Conversions entre °C, °F, K…</a></li>
-                <li><a href="convertisseurs/index.html?cat=area">Aire – Conversions entre m², ft²…</a></li>
-                <li><a href="convertisseurs/index.html?cat=volume">Volume – Conversions entre L, gal, m³…</a></li>
-                <li><a href="convertisseurs/index.html?cat=time">Temps – Conversions entre s, min, h…</a></li>
-                <li><a href="convertisseurs/index.html?cat=frequency">Fréquence – Conversions entre Hz, kHz, MHz…</a></li>
-                <li><a href="convertisseurs/index.html?cat=speed">Vitesse – Conversions entre km/h, mph…</a></li>
-                <li><a href="convertisseurs/index.html?cat=acceleration">Accélération – Conversions entre m/s², g, ft/s²…</a></li>
-                <li><a href="convertisseurs/index.html?cat=force">Force – Conversions entre N, lbf, kgf…</a></li>
-                <li><a href="convertisseurs/index.html?cat=pressure">Pression – Conversions entre Pa, bar…</a></li>
-                <li><a href="convertisseurs/index.html?cat=energy">Énergie – Conversions entre J, kWh…</a></li>
-                <li><a href="convertisseurs/index.html?cat=power">Puissance – Conversions entre W, kW, ch…</a></li>
-                <li><a href="convertisseurs/index.html?cat=density">Densité – Conversions entre kg/m³, g/cm³, lb/ft³…</a></li>
-                <li><a href="convertisseurs/index.html?cat=flow">Débit – Conversions entre m³/s, L/min, gal/min…</a></li>
-                <li><a href="convertisseurs/index.html?cat=torque">Couple – Conversions entre N·m, lb·ft…</a></li>
-                <li><a href="convertisseurs/index.html?cat=angle">Angle – Conversions entre rad, °, grad…</a></li>
-                <li><a href="convertisseurs/index.html?cat=data">Données – Conversions entre Mo, Go…</a></li>
+                <li class="category-card category-card--length"><a href="convertisseurs/index.html?cat=length">Longueur – Conversions entre m, ft, km, mi, cm, in…</a></li>
+                <li class="category-card category-card--weight"><a href="convertisseurs/index.html?cat=weight">Masse – Conversions entre kg, lb, g, oz…</a></li>
+                <li class="category-card category-card--temperature"><a href="convertisseurs/index.html?cat=temperature">Température – Conversions entre °C, °F, K…</a></li>
+                <li class="category-card category-card--area"><a href="convertisseurs/index.html?cat=area">Aire – Conversions entre m², ft²…</a></li>
+                <li class="category-card category-card--volume"><a href="convertisseurs/index.html?cat=volume">Volume – Conversions entre L, gal, m³…</a></li>
+                <li class="category-card category-card--time"><a href="convertisseurs/index.html?cat=time">Temps – Conversions entre s, min, h…</a></li>
+                <li class="category-card category-card--frequency"><a href="convertisseurs/index.html?cat=frequency">Fréquence – Conversions entre Hz, kHz, MHz…</a></li>
+                <li class="category-card category-card--speed"><a href="convertisseurs/index.html?cat=speed">Vitesse – Conversions entre km/h, mph…</a></li>
+                <li class="category-card category-card--acceleration"><a href="convertisseurs/index.html?cat=acceleration">Accélération – Conversions entre m/s², g, ft/s²…</a></li>
+                <li class="category-card category-card--force"><a href="convertisseurs/index.html?cat=force">Force – Conversions entre N, lbf, kgf…</a></li>
+                <li class="category-card category-card--pressure"><a href="convertisseurs/index.html?cat=pressure">Pression – Conversions entre Pa, bar…</a></li>
+                <li class="category-card category-card--energy"><a href="convertisseurs/index.html?cat=energy">Énergie – Conversions entre J, kWh…</a></li>
+                <li class="category-card category-card--power"><a href="convertisseurs/index.html?cat=power">Puissance – Conversions entre W, kW, ch…</a></li>
+                <li class="category-card category-card--density"><a href="convertisseurs/index.html?cat=density">Densité – Conversions entre kg/m³, g/cm³, lb/ft³…</a></li>
+                <li class="category-card category-card--flow"><a href="convertisseurs/index.html?cat=flow">Débit – Conversions entre m³/s, L/min, gal/min…</a></li>
+                <li class="category-card category-card--torque"><a href="convertisseurs/index.html?cat=torque">Couple – Conversions entre N·m, lb·ft…</a></li>
+                <li class="category-card category-card--angle"><a href="convertisseurs/index.html?cat=angle">Angle – Conversions entre rad, °, grad…</a></li>
+                <li class="category-card category-card--data"><a href="convertisseurs/index.html?cat=data">Données – Conversions entre Mo, Go…</a></li>
             </ul>
         </section>
         <section>

--- a/src/js/temperature.js
+++ b/src/js/temperature.js
@@ -1,24 +1,24 @@
 export function convertTemperature(value, from, to) {
   let celsius;
   switch (from) {
-    case 'c':
+    case "c":
       celsius = value;
       break;
-    case 'f':
-      celsius = (value - 32) * 5 / 9;
+    case "f":
+      celsius = ((value - 32) * 5) / 9;
       break;
-    case 'k':
+    case "k":
       celsius = value - 273.15;
       break;
     default:
       return NaN;
   }
   switch (to) {
-    case 'c':
+    case "c":
       return celsius;
-    case 'f':
-      return celsius * 9 / 5 + 32;
-    case 'k':
+    case "f":
+      return (celsius * 9) / 5 + 32;
+    case "k":
       return celsius + 273.15;
     default:
       return NaN;


### PR DESCRIPTION
## Summary
- add unique modifier classes to each category link on the home page
- style category cards with a shared base class and dedicated gradient backgrounds per modifier
- format the temperature conversion module to comply with the Prettier configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2af6d06e88329a5c40f2665072870