### PR TITLE
feat: refactor new spot modal for accessibility

### DIFF
--- a/data/mushrooms.json
+++ b/data/mushrooms.json
@@ -1,0 +1,22 @@
+[
+  {"id": "cepe-bordeaux", "name": "Cèpe de Bordeaux", "latin": "Boletus edulis"},
+  {"id": "girolle", "name": "Girolle commune", "latin": "Cantharellus cibarius"},
+  {"id": "morille-blonde", "name": "Morille blonde", "latin": "Morchella esculenta"},
+  {"id": "pied-mouton", "name": "Pied-de-mouton", "latin": "Hydnum repandum"},
+  {"id": "trompette-mort", "name": "Trompette de la mort", "latin": "Craterellus cornucopioides"},
+  {"id": "chanterelle-tube", "name": "Chanterelle en tube", "latin": "Cantharellus tubaeformis"},
+  {"id": "coulemelle", "name": "Coulemelle", "latin": "Macrolepiota procera"},
+  {"id": "amanite-cesars", "name": "Amanite des Césars", "latin": "Amanita caesarea"},
+  {"id": "pleurote-huitre", "name": "Pleurote en huître", "latin": "Pleurotus ostreatus"},
+  {"id": "tricholome-saint-georges", "name": "Tricholome de la Saint-Georges", "latin": "Calocybe gambosa"},
+  {"id": "rose-pres", "name": "Rosé-des-prés", "latin": "Agaricus campestris"},
+  {"id": "lactaire-delicieux", "name": "Lactaire délicieux", "latin": "Lactarius deliciosus"},
+  {"id": "marasme-oreades", "name": "Marasme des Oréades", "latin": "Marasmius oreades"},
+  {"id": "coprin-chevelu", "name": "Coprin chevelu", "latin": "Coprinus comatus"},
+  {"id": "mousseron-automne", "name": "Mousseron d'automne", "latin": "Clitocybe nebularis"},
+  {"id": "armillaire-ventru", "name": "Armillaire ventru", "latin": "Armillaria mellea"},
+  {"id": "shiitake", "name": "Shiitake", "latin": "Lentinula edodes"},
+  {"id": "pleurote-orme", "name": "Pleurote de l'orme", "latin": "Pleurotus pulmonarius"},
+  {"id": "agaric-jaunissant", "name": "Agaric jaunissant", "latin": "Agaricus xanthodermus"},
+  {"id": "agaric-des-bois", "name": "Agaric des bois", "latin": "Agaricus silvaticus"}
+]

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,3 +1,19 @@
+:root {
+  --color-primary: #1456e2;
+  --color-text: #0e1116;
+  --color-bg: #ffffff;
+  --color-muted: #edf1f7;
+  --color-muted-strong: #98a2b3;
+  --color-success: #10b981;
+  --color-warn: #f97316;
+  --radius-8: 8px;
+  --radius-12: 12px;
+  --radius-16: 16px;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+  --focus-ring: 0 0 0 2px var(--color-primary);
+  --transition-standard: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 body {
   margin: 0;
   font-family:
@@ -131,15 +147,47 @@ footer nav a {
 }
 
 .btn {
-  padding: 0.5rem;
-  border: 1px solid #d2d2d7;
-  border-radius: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border: none;
+  border-radius: var(--radius-12);
   font-size: 1rem;
-  background: #007acc;
-  color: #fff;
+  font-weight: 600;
+  background: var(--color-primary);
+  color: #ffffff;
   cursor: pointer;
   min-width: 44px;
   min-height: 44px;
+  transition:
+    background-color var(--transition-standard),
+    transform var(--transition-standard);
+}
+
+.btn:hover {
+  background-color: #0f46b8;
+}
+
+.btn:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: var(--color-muted);
+  color: var(--color-text);
+  border: 1px solid var(--color-muted-strong);
+}
+
+.btn-secondary:hover {
+  background: #d7deea;
 }
 
 .error {
@@ -197,4 +245,705 @@ footer nav a {
   .map-actions .btn {
     width: auto;
   }
+}
+
+.no-scroll {
+  overflow: hidden;
+}
+
+.new-spot-overlay[hidden] {
+  display: none;
+}
+
+.new-spot-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.new-spot-scrim {
+  position: absolute;
+  inset: 0;
+  background: rgba(14, 17, 22, 0.6);
+}
+
+.new-spot-modal {
+  position: relative;
+  z-index: 1;
+  width: min(100%, 36rem);
+  max-height: calc(100vh - 2rem);
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: var(--radius-16);
+  box-shadow: 0 16px 40px rgba(14, 17, 22, 0.24);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.new-spot-form {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.new-spot-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1.5rem 1.5rem 0;
+}
+
+.new-spot-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.new-spot-close {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: var(--radius-8);
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.new-spot-close:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.new-spot-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.new-spot-footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  border-top: 1px solid var(--color-muted-strong);
+  background: linear-gradient(180deg, transparent, rgba(237, 241, 247, 0.6));
+}
+
+.ns-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.ns-section-title {
+  margin: 0;
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.ns-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.ns-field-block {
+  gap: 0.75rem;
+}
+
+.ns-label,
+.ns-label-inline {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.ns-label-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ns-input,
+.ns-input-file,
+.ns-checkbox {
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.ns-input,
+.ns-input-file {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--color-muted-strong);
+  border-radius: var(--radius-12);
+  background: var(--color-bg);
+  color: var(--color-text);
+  min-height: 44px;
+  transition:
+    box-shadow var(--transition-standard),
+    border-color var(--transition-standard);
+}
+
+.ns-input-file {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.ns-input:focus-visible,
+.ns-input-file:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+  border-color: transparent;
+}
+
+.ns-input[aria-invalid="true"],
+.ns-checkbox[aria-invalid="true"] {
+  border-color: var(--color-warn);
+  box-shadow: 0 0 0 1px var(--color-warn);
+}
+
+.ns-help {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-muted-strong);
+}
+
+.ns-error {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--color-warn);
+}
+
+.ns-inline-warning {
+  margin: 0.25rem 0 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-8);
+  background: rgba(249, 115, 22, 0.12);
+  color: var(--color-text);
+  font-size: 0.875rem;
+}
+
+.ns-map {
+  position: relative;
+  border-radius: var(--radius-16);
+  border: 1px solid var(--color-muted-strong);
+  overflow: hidden;
+  background: var(--color-muted);
+  min-height: 240px;
+  touch-action: none;
+  cursor: grab;
+}
+
+.ns-map.is-dragging,
+.ns-map.is-dragging .ns-map-pin {
+  cursor: grabbing;
+}
+
+.ns-map-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+  pointer-events: none;
+}
+
+.ns-map-pin {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 56px;
+  height: 56px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: grab;
+  text-indent: -9999px;
+  box-shadow: 0 8px 20px rgba(20, 86, 226, 0.3);
+}
+
+.ns-map-pin::after {
+  content: "";
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #ffffff;
+  box-shadow: inset 0 0 0 4px rgba(20, 86, 226, 0.3);
+}
+
+.ns-map-pin:focus-visible {
+  outline: var(--focus-ring);
+}
+
+.ns-coords {
+  font-size: 0.9rem;
+  color: var(--color-text);
+}
+
+.ns-link-button {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  padding: 0 0.25rem;
+  font-size: 0.95rem;
+  text-decoration: underline;
+  display: inline-flex;
+  align-items: center;
+  min-height: 44px;
+  min-width: 44px;
+  border-radius: var(--radius-8);
+}
+
+.ns-link-button:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.ns-combobox {
+  position: relative;
+}
+
+.ns-combobox-list {
+  position: absolute;
+  z-index: 2;
+  top: calc(100% + 0.25rem);
+  left: 0;
+  right: 0;
+  max-height: 14rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0.25rem 0;
+  list-style: none;
+  background: var(--color-bg);
+  border: 1px solid var(--color-muted-strong);
+  border-radius: var(--radius-12);
+  box-shadow: var(--shadow-sm);
+}
+
+.ns-combobox-list[hidden] {
+  display: none;
+}
+
+.ns-combobox-option {
+  padding: 0.5rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  cursor: pointer;
+}
+
+.ns-combobox-option.is-active,
+.ns-combobox-option:hover {
+  background: var(--color-muted);
+}
+
+.ns-option-name {
+  font-weight: 600;
+}
+
+.ns-option-latin {
+  font-size: 0.85rem;
+  color: var(--color-muted-strong);
+}
+
+.ns-combobox-empty {
+  padding: 0.5rem 1rem;
+  color: var(--color-muted-strong);
+}
+
+.ns-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.ns-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--color-muted);
+  color: var(--color-text);
+  border-radius: var(--radius-16);
+  padding: 0.5rem 0.75rem;
+}
+
+.ns-chip-label {
+  font-size: 0.95rem;
+}
+
+.ns-chip-remove {
+  border: none;
+  background: transparent;
+  color: var(--color-text);
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.ns-chip-remove:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.ns-shortcuts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ns-fieldset {
+  border: 1px solid var(--color-muted-strong);
+  border-radius: var(--radius-12);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ns-legend {
+  font-weight: 600;
+}
+
+.ns-radio {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.ns-radio-input {
+  min-width: 20px;
+  min-height: 20px;
+}
+
+.ns-radio-label {
+  font-size: 0.95rem;
+}
+
+.ns-rating {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.ns-rating-input {
+  position: absolute;
+  opacity: 0;
+}
+
+.ns-rating-label {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: transform var(--transition-standard);
+}
+
+.ns-rating-label:hover .ns-rating-star,
+.ns-rating-label:focus-visible .ns-rating-star {
+  transform: scale(1.1);
+}
+
+.ns-rating-input:focus-visible + .ns-rating-label {
+  outline: var(--focus-ring);
+  outline-offset: 4px;
+}
+
+.ns-rating-star {
+  font-size: 1.25rem;
+  color: var(--color-warn);
+  transition: transform var(--transition-standard);
+}
+
+.ns-rating-tooltip {
+  position: absolute;
+  bottom: -1.75rem;
+  background: var(--color-text);
+  color: #ffffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-8);
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-standard);
+}
+
+.ns-rating-label:hover .ns-rating-tooltip,
+.ns-rating-label:focus-visible .ns-rating-tooltip {
+  opacity: 1;
+}
+
+.ns-photo-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
+}
+
+.ns-photo {
+  margin: 0;
+  background: var(--color-muted);
+  border-radius: var(--radius-12);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.ns-photo-img {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+}
+
+.ns-photo-actions {
+  display: flex;
+  justify-content: space-between;
+  padding: 0 0.5rem;
+}
+
+.ns-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.ns-toggle-button {
+  position: relative;
+  width: 72px;
+  height: 36px;
+  border-radius: 999px;
+  background: var(--color-muted-strong);
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.ns-toggle-button.is-active {
+  background: var(--color-primary);
+  justify-content: flex-end;
+}
+
+.ns-toggle-button:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.ns-toggle-handle {
+  display: block;
+  width: 32px;
+  height: 32px;
+  margin: 2px;
+  border-radius: 50%;
+  background: #ffffff;
+  transition: transform var(--transition-standard);
+}
+
+.ns-toggle-label {
+  position: absolute;
+  inset: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.ns-consent {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.ns-checkbox {
+  width: 20px;
+  height: 20px;
+}
+
+.ns-link {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--color-primary);
+}
+
+.ns-link:hover,
+.ns-link:focus-visible {
+  text-decoration: underline;
+}
+
+.ns-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-12);
+  font-weight: 600;
+  font-size: 1rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  min-height: 44px;
+  transition:
+    background-color var(--transition-standard),
+    color var(--transition-standard);
+}
+
+.ns-button-primary {
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.ns-button-primary:hover {
+  background: #0f46b8;
+}
+
+.ns-button-secondary {
+  background: var(--color-muted);
+  color: var(--color-text);
+  border-color: var(--color-muted-strong);
+}
+
+.ns-button-secondary:hover {
+  background: #d7deea;
+}
+
+.ns-button-danger {
+  background: var(--color-warn);
+  color: var(--color-text);
+}
+
+.ns-button-danger:hover {
+  background: #dd5f10;
+}
+
+.ns-button-ghost {
+  background: transparent;
+  color: var(--color-primary);
+}
+
+.ns-button:focus-visible {
+  outline: var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.ns-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ns-button-spinner {
+  display: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.6);
+  border-top-color: #ffffff;
+  animation: ns-spin 0.8s linear infinite;
+}
+
+.ns-button.is-loading .ns-button-spinner {
+  display: inline-block;
+}
+
+.new-spot-confirm {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(14, 17, 22, 0.45);
+  padding: 1.5rem;
+}
+
+.new-spot-confirm[hidden] {
+  display: none;
+}
+
+.new-spot-confirm-card {
+  background: var(--color-bg);
+  color: var(--color-text);
+  border-radius: var(--radius-16);
+  padding: 2rem;
+  max-width: 24rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.new-spot-confirm-title {
+  margin: 0;
+}
+
+.new-spot-confirm-description {
+  margin: 0;
+  color: var(--color-muted-strong);
+}
+
+.new-spot-confirm-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .new-spot-overlay {
+    align-items: center;
+  }
+
+  .new-spot-confirm-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+}
+
+@keyframes ns-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -1,3 +1,5 @@
+import { initNewSpotModal } from "./new-spot-modal.js";
+
 const DEFAULT_LOCATION = { lat: 48.8566, lng: 2.3522 };
 const MAP_DELTA = 0.02;
 
@@ -42,6 +44,7 @@ function updateMap(frame, container, coords) {
 }
 
 export function initializeMapPage() {
+  initNewSpotModal();
   const frame = document.getElementById("map-frame");
   const button = document.getElementById("geolocate-button");
   const status = document.getElementById("map-status");

--- a/src/js/new-spot-modal.js
+++ b/src/js/new-spot-modal.js
@@ -1,0 +1,1950 @@
+const DEFAULT_COORDS = { lat: 48.8566, lng: 2.3522 };
+const MAP_DELTA = 0.02;
+const KEYBOARD_STEP = 0.00009;
+const KEYBOARD_STEP_FAST = 0.0009;
+const PRECISION_LEVELS = [
+  {
+    value: "exact",
+    label: "Exacte",
+    rounding: 4,
+    announcement: "Coordonnées exactes",
+  },
+  {
+    value: "100m",
+    label: "≈100 m",
+    rounding: 3,
+    announcement: "Coordonnées approximatives à 100 mètres",
+  },
+  {
+    value: "500m",
+    label: "≈500 m",
+    rounding: 2,
+    announcement: "Coordonnées approximatives à 500 mètres",
+  },
+  {
+    value: "1km",
+    label: "≈1 km",
+    rounding: 1,
+    announcement: "Coordonnées approximatives à un kilomètre",
+  },
+];
+const ACCEPTED_FILE_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+  "image/heif",
+  "image/jpg",
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_PHOTOS = 8;
+const MUSHROOMS_ENDPOINT = "/data/mushrooms.json";
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatCoordinate(value, decimals, min = -180, max = 180) {
+  return clamp(value, min, max).toFixed(decimals);
+}
+
+function buildMapUrl({ lat, lng }) {
+  const latClamped = clamp(lat, -90, 90);
+  const lngClamped = clamp(lng, -180, 180);
+  const delta = MAP_DELTA;
+  const left = formatCoordinate(lngClamped - delta, 6, -180, 180);
+  const right = formatCoordinate(lngClamped + delta, 6, -180, 180);
+  const bottom = formatCoordinate(latClamped - delta, 6, -90, 90);
+  const top = formatCoordinate(latClamped + delta, 6, -90, 90);
+  const bbox = `${left}%2C${bottom}%2C${right}%2C${top}`;
+  const markerLat = formatCoordinate(latClamped, 6, -90, 90);
+  const markerLng = formatCoordinate(lngClamped, 6, -180, 180);
+  const marker = `${markerLat}%2C${markerLng}`;
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${marker}`;
+}
+
+function formatApproximateCoords(coords, precision) {
+  const precisionConfig = PRECISION_LEVELS.find(
+    (level) => level.value === precision,
+  );
+  const decimals = precisionConfig ? precisionConfig.rounding : 4;
+  const latText = clamp(coords.lat, -90, 90).toFixed(decimals);
+  const lngText = clamp(coords.lng, -180, 180).toFixed(decimals);
+  return `${latText}°, ${lngText}°`;
+}
+
+function createElement(tag, options = {}) {
+  const element = document.createElement(tag);
+  if (options.className) {
+    element.className = options.className;
+  }
+  if (options.attrs) {
+    Object.entries(options.attrs).forEach(([key, value]) => {
+      if (value === null || typeof value === "undefined") {
+        return;
+      }
+      element.setAttribute(key, value);
+    });
+  }
+  if (options.text) {
+    element.textContent = options.text;
+  }
+  if (options.html) {
+    element.innerHTML = options.html;
+  }
+  return element;
+}
+
+function buildPrecisionControls(selectedValue) {
+  const container = createElement("fieldset", {
+    className: "ns-fieldset",
+    attrs: { "aria-describedby": "location-help location-precision-help" },
+  });
+  const legend = createElement("legend", {
+    className: "ns-legend",
+    text: "Précision",
+  });
+  container.appendChild(legend);
+  const hint = createElement("p", {
+    className: "ns-help",
+    id: "location-precision-help",
+    text: "Choisissez le niveau de précision partagé.",
+  });
+  container.appendChild(hint);
+
+  PRECISION_LEVELS.forEach((level) => {
+    const item = createElement("div", { className: "ns-radio" });
+    const inputId = `location-precision-${level.value}`;
+    const input = createElement("input", {
+      className: "ns-radio-input",
+      attrs: {
+        type: "radio",
+        id: inputId,
+        name: "location-precision",
+        value: level.value,
+        checked: level.value === selectedValue ? "" : null,
+      },
+    });
+    const label = createElement("label", {
+      className: "ns-radio-label",
+      attrs: { for: inputId },
+      text: level.label,
+    });
+    item.appendChild(input);
+    item.appendChild(label);
+    container.appendChild(item);
+  });
+
+  return container;
+}
+
+function formatDate(date) {
+  if (!date) {
+    return "";
+  }
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getFocusableElements(root) {
+  return Array.from(
+    root.querySelectorAll(
+      'a[href], button:not([disabled]), textarea, input:not([type="hidden"]):not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  );
+}
+
+function isAcceptedFileType(file) {
+  const type = file.type ? file.type.toLowerCase() : "";
+  if (ACCEPTED_FILE_TYPES.includes(type)) {
+    return true;
+  }
+  if (!type && file.name) {
+    const extension = file.name.split(".").pop().toLowerCase();
+    return ["jpg", "jpeg", "png", "heic", "heif"].includes(extension);
+  }
+  return false;
+}
+
+class NewSpotModal {
+  constructor(triggerButton, container) {
+    this.triggerButton = triggerButton;
+    this.container = container;
+    this.overlay = null;
+    this.modal = null;
+    this.confirmDialog = null;
+    this.focusTrapRoot = null;
+    this.statusRegion = null;
+    this.mushrooms = [];
+    this.isOpen = false;
+    this.isDirty = false;
+    this.isSubmitting = false;
+    this.state = {
+      coords: { ...DEFAULT_COORDS },
+      precision: PRECISION_LEVELS[0].value,
+      species: [],
+      photos: [],
+      showRawCoords: false,
+      isPublic: false,
+      lastHarvest: "",
+      rating: "",
+      publicConsent: false,
+      hasCustomLocation: false,
+    };
+    this.elements = {};
+    this.activeSuggestionIndex = -1;
+    this.pointerMoveData = null;
+    this.baseMapDescription =
+      "location-help location-keyboard map-coords-display";
+    this.boundHandleKeydown = (event) => this.handleKeydown(event);
+    this.boundDocumentClick = (event) => this.handleDocumentClick(event);
+    this.boundPointerMove = (event) => this.handlePointerMove(event);
+    this.boundPointerUp = (event) => this.stopPointerMove(event);
+
+    this.build();
+    this.attachTrigger();
+  }
+
+  attachTrigger() {
+    this.triggerButton.setAttribute("aria-expanded", "false");
+    this.triggerButton.addEventListener("click", () => {
+      this.open();
+    });
+  }
+
+  build() {
+    this.overlay = createElement("div", {
+      className: "new-spot-overlay",
+      attrs: { "data-new-spot-overlay": "", hidden: "" },
+    });
+
+    const scrim = createElement("div", {
+      className: "new-spot-scrim",
+      attrs: { "data-new-spot-scrim": "" },
+    });
+
+    this.modal = createElement("div", {
+      className: "new-spot-modal",
+      attrs: {
+        id: "new-spot-modal",
+        role: "dialog",
+        "aria-modal": "true",
+        "aria-labelledby": "new-spot-title",
+        "data-new-spot-main": "",
+      },
+    });
+
+    const form = createElement("form", {
+      className: "new-spot-form",
+      attrs: { novalidate: "" },
+    });
+
+    const header = createElement("header", { className: "new-spot-header" });
+    const title = createElement("h2", {
+      id: "new-spot-title",
+      className: "new-spot-title",
+      text: "Ajouter un coin de champignons",
+    });
+    header.appendChild(title);
+
+    const closeButton = createElement("button", {
+      className: "new-spot-close",
+      attrs: {
+        type: "button",
+        "data-close-modal": "",
+        "aria-label": "Fermer la fenêtre",
+      },
+    });
+    closeButton.innerHTML = '<span aria-hidden="true">×</span>';
+    header.appendChild(closeButton);
+
+    const body = createElement("div", { className: "new-spot-body" });
+
+    body.appendChild(this.buildDetailsSection());
+    body.appendChild(this.buildLocationSection());
+    body.appendChild(this.buildSpeciesSection());
+    body.appendChild(this.buildHarvestSection());
+    body.appendChild(this.buildPhotosSection());
+    body.appendChild(this.buildPrivacySection());
+
+    const footer = createElement("footer", { className: "new-spot-footer" });
+    const cancelButton = createElement("button", {
+      className: "ns-button ns-button-secondary",
+      attrs: { type: "button", "data-cancel-modal": "" },
+      text: "Annuler",
+    });
+    const submitButton = createElement("button", {
+      className: "ns-button ns-button-primary",
+      attrs: { type: "submit", "data-submit-modal": "" },
+    });
+    submitButton.innerHTML =
+      '<span class="ns-button-spinner" aria-hidden="true"></span><span data-submit-label>Créer</span>';
+    footer.appendChild(cancelButton);
+    footer.appendChild(submitButton);
+
+    form.appendChild(header);
+    form.appendChild(body);
+    form.appendChild(footer);
+
+    this.modal.appendChild(form);
+
+    this.confirmDialog = createElement("div", {
+      className: "new-spot-confirm",
+      attrs: {
+        role: "alertdialog",
+        "aria-modal": "true",
+        "aria-labelledby": "new-spot-confirm-title",
+        "aria-describedby": "new-spot-confirm-description",
+        hidden: "",
+        "data-new-spot-confirm": "",
+      },
+    });
+
+    const confirmCard = createElement("div", {
+      className: "new-spot-confirm-card",
+    });
+    const confirmTitle = createElement("h3", {
+      id: "new-spot-confirm-title",
+      className: "new-spot-confirm-title",
+      text: "Abandonner la création ?",
+    });
+    const confirmDescription = createElement("p", {
+      id: "new-spot-confirm-description",
+      className: "new-spot-confirm-description",
+      text: "Vous pourrez enregistrer un brouillon pour reprendre plus tard.",
+    });
+
+    const confirmButtons = createElement("div", {
+      className: "new-spot-confirm-actions",
+    });
+    const saveDraftButton = createElement("button", {
+      className: "ns-button ns-button-primary",
+      attrs: { type: "button", "data-confirm-draft": "" },
+      text: "Enregistrer le brouillon",
+    });
+    const discardButton = createElement("button", {
+      className: "ns-button ns-button-danger",
+      attrs: { type: "button", "data-confirm-discard": "" },
+      text: "Annuler la création",
+    });
+    const backButton = createElement("button", {
+      className: "ns-button ns-button-ghost",
+      attrs: { type: "button", "data-confirm-back": "" },
+      text: "Revenir au formulaire",
+    });
+
+    confirmButtons.appendChild(saveDraftButton);
+    confirmButtons.appendChild(discardButton);
+    confirmButtons.appendChild(backButton);
+
+    confirmCard.appendChild(confirmTitle);
+    confirmCard.appendChild(confirmDescription);
+    confirmCard.appendChild(confirmButtons);
+    this.confirmDialog.appendChild(confirmCard);
+
+    this.statusRegion = createElement("div", {
+      className: "sr-only",
+      attrs: { "aria-live": "polite", "data-status-region": "" },
+    });
+
+    this.overlay.appendChild(scrim);
+    this.overlay.appendChild(this.modal);
+    this.overlay.appendChild(this.confirmDialog);
+    this.overlay.appendChild(this.statusRegion);
+
+    this.container.appendChild(this.overlay);
+
+    this.cacheElements();
+    this.bindEvents();
+  }
+
+  cacheElements() {
+    const form = this.modal.querySelector("form");
+    this.elements.form = form;
+    this.elements.closeButton = this.modal.querySelector("[data-close-modal]");
+    this.elements.cancelButton = this.modal.querySelector(
+      "[data-cancel-modal]",
+    );
+    this.elements.submitButton = this.modal.querySelector(
+      "[data-submit-modal]",
+    );
+    this.elements.submitLabel = this.modal.querySelector("[data-submit-label]");
+
+    this.elements.nameInput = form.querySelector("#spot-name");
+    this.elements.nameError = form.querySelector("#spot-name-error");
+
+    this.elements.mapFrame = form.querySelector("#spot-map-frame");
+    this.elements.mapInteractive = form.querySelector("[data-map-interactive]");
+    this.elements.mapField = form.querySelector("[data-map-field]");
+    this.elements.mapPin = form.querySelector("[data-map-pin]");
+    this.elements.mapError = form.querySelector("#spot-location-error");
+    this.elements.mapCoords = form.querySelector("[data-map-coords]");
+    this.elements.mapToggleButton = form.querySelector("[data-toggle-coords]");
+    this.elements.rawCoords = form.querySelector("[data-raw-coords]");
+    this.elements.precisionRadios = Array.from(
+      form.querySelectorAll('input[name="location-precision"]'),
+    );
+    this.elements.precisionError = form.querySelector("#spot-precision-error");
+    this.elements.precisionHint = form.querySelector(
+      "#location-precision-help",
+    );
+    this.elements.precisionAlert = form.querySelector(
+      "#public-precision-alert",
+    );
+
+    this.elements.speciesInput = form.querySelector("#spot-species");
+    this.elements.speciesList = form.querySelector("[data-species-list]");
+    this.elements.speciesContainer = form.querySelector(
+      "[data-selected-species]",
+    );
+    this.elements.speciesHelp = form.querySelector("#spot-species-help");
+    this.elements.speciesError = form.querySelector("#spot-species-error");
+
+    this.elements.harvestDate = form.querySelector("#spot-harvest-date");
+    this.elements.harvestError = form.querySelector("#spot-harvest-error");
+    this.elements.todayShortcut = form.querySelector("[data-shortcut-today]");
+    this.elements.yesterdayShortcut = form.querySelector(
+      "[data-shortcut-yesterday]",
+    );
+    this.elements.ratingInputs = Array.from(
+      form.querySelectorAll('input[name="spot-rating"]'),
+    );
+
+    this.elements.photosInput = form.querySelector("#spot-photos");
+    this.elements.photoGrid = form.querySelector("[data-photo-grid]");
+    this.elements.photosError = form.querySelector("#spot-photos-error");
+
+    this.elements.privacyToggle = form.querySelector("[data-privacy-toggle]");
+    this.elements.privacyStatus = form.querySelector("[data-privacy-status]");
+    this.elements.publicConsent = form.querySelector("#spot-public-consent");
+    this.elements.publicConsentWrapper = form.querySelector(
+      "[data-public-consent]",
+    );
+    this.elements.publicError = form.querySelector("#spot-public-error");
+    this.elements.securityLink = form.querySelector("[data-security-link]");
+
+    this.elements.confirm = {
+      wrapper: this.confirmDialog,
+      saveDraft: this.confirmDialog.querySelector("[data-confirm-draft]"),
+      discard: this.confirmDialog.querySelector("[data-confirm-discard]"),
+      back: this.confirmDialog.querySelector("[data-confirm-back]"),
+    };
+  }
+
+  bindEvents() {
+    this.elements.closeButton.addEventListener("click", () =>
+      this.requestClose(),
+    );
+    this.elements.cancelButton.addEventListener("click", () =>
+      this.requestClose(),
+    );
+    const scrim = this.overlay.querySelector("[data-new-spot-scrim]");
+    if (scrim) {
+      scrim.addEventListener("click", () => {
+        if (!this.confirmDialog.hidden) {
+          return;
+        }
+        this.requestClose();
+      });
+    }
+
+    this.elements.form.addEventListener("submit", (event) =>
+      this.handleSubmit(event),
+    );
+
+    this.elements.nameInput.addEventListener("input", () => {
+      this.setDirty();
+      this.validateName();
+    });
+
+    this.elements.mapPin.addEventListener("keydown", (event) =>
+      this.handleMapKeydown(event),
+    );
+    this.elements.mapInteractive.addEventListener("pointerdown", (event) =>
+      this.startPointerMove(event),
+    );
+    window.addEventListener("pointerup", this.boundPointerUp);
+    window.addEventListener("pointermove", this.boundPointerMove);
+
+    this.elements.mapToggleButton.addEventListener("click", () =>
+      this.toggleRawCoords(),
+    );
+    this.elements.precisionRadios.forEach((radio) =>
+      radio.addEventListener("change", () => this.handlePrecisionChange()),
+    );
+
+    this.elements.speciesInput.addEventListener("input", (event) =>
+      this.handleSpeciesInput(event),
+    );
+    this.elements.speciesInput.addEventListener("keydown", (event) =>
+      this.handleSpeciesKeydown(event),
+    );
+    this.elements.speciesInput.addEventListener("focus", () =>
+      this.showSpeciesSuggestions(),
+    );
+    document.addEventListener("click", this.boundDocumentClick);
+
+    this.elements.todayShortcut.addEventListener("click", () =>
+      this.setHarvestShortcut(0),
+    );
+    this.elements.yesterdayShortcut.addEventListener("click", () =>
+      this.setHarvestShortcut(1),
+    );
+    this.elements.harvestDate.addEventListener("change", () =>
+      this.handleHarvestChange(),
+    );
+    this.elements.harvestDate.setAttribute("max", formatDate(new Date()));
+
+    this.elements.ratingInputs.forEach((input) =>
+      input.addEventListener("change", () => {
+        this.setDirty();
+        this.state.rating = input.value;
+      }),
+    );
+
+    this.elements.photosInput.addEventListener("change", (event) =>
+      this.handlePhotosChange(event),
+    );
+
+    this.elements.privacyToggle.addEventListener("click", () =>
+      this.togglePrivacy(),
+    );
+    this.elements.publicConsent.addEventListener("change", () =>
+      this.handlePublicConsentChange(),
+    );
+
+    this.elements.confirm.saveDraft.addEventListener("click", () =>
+      this.saveDraftAndClose(),
+    );
+    this.elements.confirm.discard.addEventListener("click", () =>
+      this.forceClose(),
+    );
+    this.elements.confirm.back.addEventListener("click", () =>
+      this.closeConfirm(),
+    );
+
+    this.overlay.addEventListener("keydown", this.boundHandleKeydown);
+  }
+
+  async loadMushrooms() {
+    if (this.mushrooms.length) {
+      return;
+    }
+    try {
+      const response = await fetch(MUSHROOMS_ENDPOINT);
+      if (!response.ok) {
+        throw new Error("Impossible de charger la liste des espèces.");
+      }
+      const data = await response.json();
+      if (Array.isArray(data)) {
+        this.mushrooms = data;
+      } else {
+        this.mushrooms = Object.entries(data).map(([id, info]) => ({
+          id,
+          ...info,
+        }));
+      }
+    } catch (error) {
+      this.setStatus(error.message || "Erreur lors du chargement des espèces.");
+      this.elements.speciesInput.disabled = true;
+      this.elements.speciesInput.setAttribute("aria-disabled", "true");
+    }
+  }
+
+  restoreDraft() {
+    let rawDraft;
+    try {
+      rawDraft = window.localStorage.getItem("mesureconvert-new-spot-draft");
+    } catch (error) {
+      console.warn("Impossible de récupérer le brouillon", error);
+      return;
+    }
+    if (!rawDraft) {
+      return;
+    }
+
+    let draft;
+    try {
+      draft = JSON.parse(rawDraft);
+    } catch (error) {
+      console.warn("Brouillon illisible", error);
+      return;
+    }
+
+    if (!draft || typeof draft !== "object") {
+      return;
+    }
+
+    if (typeof draft.name === "string") {
+      this.elements.nameInput.value = draft.name;
+    }
+
+    if (
+      draft.precision &&
+      PRECISION_LEVELS.some((level) => level.value === draft.precision)
+    ) {
+      this.state.precision = draft.precision;
+    } else {
+      this.state.precision = PRECISION_LEVELS[0].value;
+    }
+    this.elements.precisionRadios.forEach((radio) => {
+      radio.checked = radio.value === this.state.precision;
+    });
+
+    if (
+      draft.coords &&
+      typeof draft.coords.lat === "number" &&
+      typeof draft.coords.lng === "number"
+    ) {
+      this.state.coords = draft.coords;
+      this.state.hasCustomLocation = Boolean(draft.hasCustomLocation);
+    } else {
+      this.state.coords = { ...DEFAULT_COORDS };
+      this.state.hasCustomLocation = false;
+    }
+
+    if (Array.isArray(draft.species)) {
+      this.state.species = draft.species;
+    } else {
+      this.state.species = [];
+    }
+    this.renderSpeciesChips();
+
+    if (typeof draft.lastHarvest === "string") {
+      this.state.lastHarvest = draft.lastHarvest;
+      this.elements.harvestDate.value = draft.lastHarvest;
+    } else {
+      this.state.lastHarvest = "";
+      this.elements.harvestDate.value = "";
+    }
+
+    if (typeof draft.rating === "string") {
+      this.state.rating = draft.rating;
+    } else {
+      this.state.rating = "";
+    }
+    this.elements.ratingInputs.forEach((input) => {
+      input.checked = input.value === this.state.rating;
+    });
+
+    this.state.isPublic = Boolean(draft.isPublic);
+    this.state.publicConsent = this.state.isPublic && Boolean(draft.consent);
+    this.updatePrivacyUI();
+    this.elements.publicConsent.checked = this.state.publicConsent;
+    this.updatePrivacyWarning();
+
+    this.updateMap();
+    this.updateCoordSummary();
+    this.updateRawCoords();
+    this.validateName();
+    this.validateSpecies();
+    this.validateHarvest();
+    if (this.state.hasCustomLocation) {
+      this.validateLocation();
+    } else {
+      this.elements.mapError.hidden = true;
+      this.elements.mapField.setAttribute(
+        "aria-describedby",
+        this.baseMapDescription,
+      );
+      this.elements.mapField.removeAttribute("aria-invalid");
+    }
+    this.validatePublicConsent();
+    this.updateSubmitState();
+    this.isDirty = false;
+
+    if (
+      draft.name ||
+      (Array.isArray(draft.species) && draft.species.length) ||
+      this.state.hasCustomLocation
+    ) {
+      this.setStatus("Brouillon chargé.");
+    }
+  }
+
+  setStatus(message) {
+    this.statusRegion.textContent = message || "";
+  }
+
+  open() {
+    if (this.isOpen) {
+      return;
+    }
+    this.isOpen = true;
+    this.overlay.hidden = false;
+    document.body.classList.add("no-scroll");
+    this.triggerButton.setAttribute("aria-expanded", "true");
+    this.focusTrapRoot = this.modal;
+    this.updateMap();
+    this.updateCoordSummary();
+    this.updateRawCoords();
+    this.updatePrivacyUI();
+    this.updateSubmitState();
+    this.restoreDraft();
+    this.elements.nameInput.focus();
+    this.loadMushrooms();
+  }
+
+  requestClose() {
+    if (!this.isDirty) {
+      this.close();
+      return;
+    }
+    this.openConfirm();
+  }
+
+  close() {
+    if (!this.isOpen) {
+      return;
+    }
+    this.isOpen = false;
+    this.overlay.hidden = true;
+    document.body.classList.remove("no-scroll");
+    this.triggerButton.setAttribute("aria-expanded", "false");
+    this.resetForm();
+    this.triggerButton.focus();
+  }
+
+  forceClose() {
+    this.closeConfirm();
+    this.isDirty = false;
+    this.close();
+  }
+
+  resetForm() {
+    this.elements.form.reset();
+    this.state = {
+      coords: { ...DEFAULT_COORDS },
+      precision: PRECISION_LEVELS[0].value,
+      species: [],
+      photos: [],
+      showRawCoords: false,
+      isPublic: false,
+      lastHarvest: "",
+      rating: "",
+      publicConsent: false,
+      hasCustomLocation: false,
+    };
+    this.clearSpeciesChips();
+    this.clearPhotoGrid();
+    this.updateMap();
+    this.updateCoordSummary();
+    this.updateRawCoords();
+    this.updatePrivacyUI();
+    this.updateSubmitState();
+    this.isDirty = false;
+    this.isSubmitting = false;
+    this.elements.speciesInput.disabled = false;
+    this.elements.speciesInput.value = "";
+    this.elements.speciesInput.removeAttribute("aria-disabled");
+    this.elements.speciesInput.setAttribute(
+      "aria-describedby",
+      "spot-species-help",
+    );
+    this.elements.speciesInput.removeAttribute("aria-invalid");
+    this.elements.mapField.setAttribute(
+      "aria-describedby",
+      this.baseMapDescription,
+    );
+    this.elements.mapField.removeAttribute("aria-invalid");
+    this.elements.nameInput.setAttribute("aria-describedby", "spot-name-help");
+    this.elements.nameInput.removeAttribute("aria-invalid");
+    this.activeSuggestionIndex = -1;
+    this.elements.speciesList.innerHTML = "";
+    this.hideSpeciesSuggestions();
+    this.elements.submitButton.removeAttribute("aria-busy");
+    this.elements.submitButton.disabled = false;
+    this.statusRegion.textContent = "";
+    this.pointerMoveData = null;
+  }
+
+  buildDetailsSection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "details-title" },
+    });
+    const title = createElement("h3", {
+      id: "details-title",
+      className: "ns-section-title",
+      text: "Détails du coin",
+    });
+    const group = createElement("div", { className: "ns-field" });
+    const label = createElement("label", {
+      attrs: { for: "spot-name" },
+      className: "ns-label",
+      text: "Nom du coin",
+    });
+    const help = createElement("p", {
+      id: "spot-name-help",
+      className: "ns-help",
+      text: "Nom visible dans vos coins.",
+    });
+    const input = createElement("input", {
+      className: "ns-input",
+      attrs: {
+        id: "spot-name",
+        name: "spot-name",
+        type: "text",
+        placeholder: "Ex. Coin de Louise – Bois de Vincennes",
+        "aria-describedby": "spot-name-help",
+        required: "",
+      },
+    });
+    const error = createElement("p", {
+      id: "spot-name-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+    group.appendChild(label);
+    group.appendChild(help);
+    group.appendChild(input);
+    group.appendChild(error);
+    section.appendChild(title);
+    section.appendChild(group);
+    return section;
+  }
+
+  buildLocationSection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "location-title" },
+    });
+    const title = createElement("h3", {
+      id: "location-title",
+      className: "ns-section-title",
+      text: "Localisation",
+    });
+
+    const mapField = createElement("div", {
+      className: "ns-field ns-field-block",
+      attrs: {
+        role: "group",
+        "aria-labelledby": "location-title",
+        "aria-describedby":
+          "location-help location-keyboard map-coords-display",
+        "data-map-field": "",
+      },
+    });
+
+    const help = createElement("p", {
+      id: "location-help",
+      className: "ns-help",
+      text: "Déplacez l’épingle pour choisir l’emplacement.",
+    });
+
+    const mapContainer = createElement("div", {
+      className: "ns-map",
+      attrs: { "data-map-interactive": "" },
+    });
+    const iframe = createElement("iframe", {
+      className: "ns-map-frame",
+      attrs: {
+        id: "spot-map-frame",
+        title: "Carte OpenStreetMap",
+        loading: "lazy",
+        tabindex: "-1",
+        "aria-hidden": "true",
+      },
+    });
+    const mapPin = createElement("button", {
+      className: "ns-map-pin",
+      attrs: {
+        type: "button",
+        "aria-describedby": "location-help location-keyboard",
+        "aria-label": "Déplacer l’épingle",
+        "data-map-pin": "",
+      },
+      text: "Épingle",
+    });
+    const keyboardHelp = createElement("p", {
+      id: "location-keyboard",
+      className: "ns-help",
+      text: "Flèches = ±10 m, Maj + flèches = ±100 m.",
+    });
+
+    mapContainer.appendChild(iframe);
+    mapContainer.appendChild(mapPin);
+
+    const coordSummary = createElement("div", {
+      className: "ns-coords",
+      attrs: { id: "map-coords-display", "data-map-coords": "" },
+    });
+
+    const toggleCoords = createElement("button", {
+      className: "ns-link-button",
+      attrs: {
+        type: "button",
+        "data-toggle-coords": "",
+        "aria-expanded": "false",
+        "aria-controls": "spot-raw-coords",
+      },
+      text: "Afficher les coordonnées",
+    });
+
+    const rawCoords = createElement("div", {
+      className: "ns-raw-coords",
+      attrs: { hidden: "", id: "spot-raw-coords", "data-raw-coords": "" },
+    });
+
+    const precisionControls = buildPrecisionControls(this.state.precision);
+    precisionControls.classList.add("ns-field-block");
+
+    const warning = createElement("p", {
+      id: "public-precision-alert",
+      className: "ns-inline-warning",
+      attrs: { role: "status", hidden: "" },
+      text: "Partager un coin exact peut attirer du monde.",
+    });
+
+    const error = createElement("p", {
+      id: "spot-location-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+
+    mapField.appendChild(help);
+    mapField.appendChild(mapContainer);
+    mapField.appendChild(keyboardHelp);
+    mapField.appendChild(coordSummary);
+    mapField.appendChild(toggleCoords);
+    mapField.appendChild(rawCoords);
+    mapField.appendChild(precisionControls);
+    mapField.appendChild(warning);
+    mapField.appendChild(error);
+
+    section.appendChild(title);
+    section.appendChild(mapField);
+
+    return section;
+  }
+
+  buildSpeciesSection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "species-title" },
+    });
+    const title = createElement("h3", {
+      id: "species-title",
+      className: "ns-section-title",
+      text: "Champignons",
+    });
+    const field = createElement("div", { className: "ns-field" });
+    const label = createElement("label", {
+      className: "ns-label",
+      attrs: { for: "spot-species" },
+      text: "Espèces trouvées",
+    });
+    const help = createElement("p", {
+      id: "spot-species-help",
+      className: "ns-help",
+      text: "Tapez pour rechercher. Noms français normalisés.",
+    });
+
+    const inputWrapper = createElement("div", { className: "ns-combobox" });
+    const input = createElement("input", {
+      className: "ns-input",
+      attrs: {
+        id: "spot-species",
+        name: "spot-species",
+        type: "text",
+        role: "combobox",
+        "aria-expanded": "false",
+        "aria-autocomplete": "list",
+        "aria-controls": "species-listbox",
+        "aria-describedby": "spot-species-help",
+        autocomplete: "off",
+        placeholder: "Rechercher une espèce",
+      },
+    });
+    const list = createElement("ul", {
+      className: "ns-combobox-list",
+      attrs: {
+        id: "species-listbox",
+        role: "listbox",
+        hidden: "",
+        "data-species-list": "",
+      },
+    });
+
+    inputWrapper.appendChild(input);
+    inputWrapper.appendChild(list);
+
+    const selectedContainer = createElement("div", {
+      className: "ns-chips",
+      attrs: { "data-selected-species": "" },
+    });
+
+    const error = createElement("p", {
+      id: "spot-species-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+
+    field.appendChild(label);
+    field.appendChild(help);
+    field.appendChild(inputWrapper);
+    field.appendChild(selectedContainer);
+    field.appendChild(error);
+
+    section.appendChild(title);
+    section.appendChild(field);
+    return section;
+  }
+
+  buildHarvestSection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "harvest-title" },
+    });
+    const title = createElement("h3", {
+      id: "harvest-title",
+      className: "ns-section-title",
+      text: "Cueillette",
+    });
+
+    const dateField = createElement("div", { className: "ns-field" });
+    const label = createElement("label", {
+      className: "ns-label",
+      attrs: { for: "spot-harvest-date" },
+      text: "Dernière cueillette",
+    });
+    const shortcuts = createElement("div", { className: "ns-shortcuts" });
+    const today = createElement("button", {
+      className: "ns-link-button",
+      attrs: { type: "button", "data-shortcut-today": "" },
+      text: "Aujourd’hui",
+    });
+    const yesterday = createElement("button", {
+      className: "ns-link-button",
+      attrs: { type: "button", "data-shortcut-yesterday": "" },
+      text: "Hier",
+    });
+    shortcuts.appendChild(today);
+    shortcuts.appendChild(yesterday);
+    const dateInput = createElement("input", {
+      className: "ns-input",
+      attrs: {
+        id: "spot-harvest-date",
+        type: "date",
+        name: "spot-harvest-date",
+      },
+    });
+    const error = createElement("p", {
+      id: "spot-harvest-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+    dateField.appendChild(label);
+    dateField.appendChild(shortcuts);
+    dateField.appendChild(dateInput);
+    dateField.appendChild(error);
+
+    const ratingFieldset = createElement("fieldset", {
+      className: "ns-fieldset",
+    });
+    const legend = createElement("legend", {
+      className: "ns-legend",
+      text: "Note du coin",
+    });
+    const ratingList = createElement("div", { className: "ns-rating" });
+    ratingFieldset.appendChild(legend);
+    ratingFieldset.appendChild(ratingList);
+
+    for (let i = 1; i <= 5; i += 1) {
+      const ratingId = `spot-rating-${i}`;
+      const input = createElement("input", {
+        className: "ns-rating-input",
+        attrs: {
+          type: "radio",
+          id: ratingId,
+          name: "spot-rating",
+          value: String(i),
+        },
+      });
+      const label = createElement("label", {
+        className: "ns-rating-label",
+        attrs: { for: ratingId },
+      });
+      label.innerHTML = `<span class="ns-rating-star" aria-hidden="true">★</span><span class="ns-rating-tooltip" role="tooltip" aria-live="off">${i}/5</span><span class="sr-only">${i} étoile${i > 1 ? "s" : ""} sur 5</span>`;
+      ratingList.appendChild(input);
+      ratingList.appendChild(label);
+    }
+
+    section.appendChild(title);
+    section.appendChild(dateField);
+    section.appendChild(ratingFieldset);
+    return section;
+  }
+
+  buildPhotosSection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "photos-title" },
+    });
+    const title = createElement("h3", {
+      id: "photos-title",
+      className: "ns-section-title",
+      text: "Photos",
+    });
+    const field = createElement("div", { className: "ns-field" });
+    const input = createElement("input", {
+      className: "ns-input-file",
+      attrs: {
+        id: "spot-photos",
+        type: "file",
+        name: "spot-photos",
+        accept: ".jpg,.jpeg,.png,.heic,.heif",
+        multiple: "",
+      },
+    });
+    const label = createElement("label", {
+      className: "ns-button ns-button-secondary",
+      attrs: { for: "spot-photos" },
+      text: "Ajouter des photos",
+    });
+    const constraints = createElement("p", {
+      className: "ns-help",
+      text: "JPG/PNG/HEIC, ≤10 Mo, jusqu’à 8 photos.",
+    });
+    const grid = createElement("div", {
+      className: "ns-photo-grid",
+      attrs: { "data-photo-grid": "" },
+    });
+    const error = createElement("p", {
+      id: "spot-photos-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+
+    field.appendChild(label);
+    field.appendChild(input);
+    field.appendChild(constraints);
+    field.appendChild(grid);
+    field.appendChild(error);
+    section.appendChild(title);
+    section.appendChild(field);
+    return section;
+  }
+
+  buildPrivacySection() {
+    const section = createElement("section", {
+      className: "ns-section",
+      attrs: { "aria-labelledby": "privacy-title" },
+    });
+    const title = createElement("h3", {
+      id: "privacy-title",
+      className: "ns-section-title",
+      text: "Confidentialité",
+    });
+    const toggleWrapper = createElement("div", { className: "ns-toggle" });
+    const toggle = createElement("button", {
+      className: "ns-toggle-button",
+      attrs: {
+        type: "button",
+        role: "switch",
+        "aria-checked": "false",
+        "data-privacy-toggle": "",
+      },
+    });
+    toggle.innerHTML =
+      '<span class="ns-toggle-handle" aria-hidden="true"></span><span class="ns-toggle-label" data-privacy-status>Privé</span>';
+
+    const consentWrapper = createElement("div", {
+      className: "ns-consent",
+      attrs: { "data-public-consent": "", hidden: "" },
+    });
+    const checkbox = createElement("input", {
+      className: "ns-checkbox",
+      attrs: { type: "checkbox", id: "spot-public-consent", required: "" },
+    });
+    const checkboxLabel = createElement("label", {
+      className: "ns-label-inline",
+      attrs: { for: "spot-public-consent" },
+      text: "Je comprends que la localisation sera visible publiquement.",
+    });
+    const error = createElement("p", {
+      id: "spot-public-error",
+      className: "ns-error",
+      attrs: { role: "alert", hidden: "" },
+    });
+    consentWrapper.appendChild(checkbox);
+    consentWrapper.appendChild(checkboxLabel);
+    consentWrapper.appendChild(error);
+
+    const link = createElement("a", {
+      className: "ns-link",
+      attrs: {
+        href: "/securite-des-donnees.html",
+        target: "_blank",
+        rel: "noopener",
+        "data-security-link": "",
+      },
+      text: "Conseils de sécurité et espèces protégées",
+    });
+
+    toggleWrapper.appendChild(toggle);
+    section.appendChild(title);
+    section.appendChild(toggleWrapper);
+    section.appendChild(consentWrapper);
+    section.appendChild(link);
+    return section;
+  }
+
+  updateMap() {
+    const { coords } = this.state;
+    this.elements.mapFrame.src = buildMapUrl(coords);
+    this.elements.mapInteractive.setAttribute(
+      "aria-label",
+      `Carte centrée sur les coordonnées ${coords.lat.toFixed(4)}°, ${coords.lng.toFixed(4)}°`,
+    );
+  }
+
+  updateCoordSummary() {
+    const { coords, precision, hasCustomLocation } = this.state;
+    if (!hasCustomLocation) {
+      this.elements.mapCoords.textContent =
+        "Déplacez l’épingle pour définir les coordonnées à partager.";
+      return;
+    }
+    this.elements.mapCoords.textContent = `Coordonnées partagées : ${formatApproximateCoords(
+      coords,
+      precision,
+    )}`;
+  }
+
+  updateRawCoords() {
+    const { coords, showRawCoords } = this.state;
+    this.elements.rawCoords.textContent = `Latitude : ${coords.lat.toFixed(6)}° / Longitude : ${coords.lng.toFixed(6)}°`;
+    this.elements.rawCoords.hidden = !showRawCoords;
+    this.elements.mapToggleButton.textContent = showRawCoords
+      ? "Masquer les coordonnées"
+      : "Afficher les coordonnées";
+    this.elements.mapToggleButton.setAttribute(
+      "aria-expanded",
+      showRawCoords ? "true" : "false",
+    );
+  }
+
+  handleMapKeydown(event) {
+    const { key } = event;
+    let deltaLat = 0;
+    let deltaLng = 0;
+    if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(key)) {
+      event.preventDefault();
+      const step = event.shiftKey ? KEYBOARD_STEP_FAST : KEYBOARD_STEP;
+      if (key === "ArrowUp") {
+        deltaLat = step;
+      } else if (key === "ArrowDown") {
+        deltaLat = -step;
+      } else if (key === "ArrowLeft") {
+        deltaLng = -step;
+      } else if (key === "ArrowRight") {
+        deltaLng = step;
+      }
+      this.moveCoords(deltaLat, deltaLng);
+    }
+  }
+
+  startPointerMove(event) {
+    if (!this.isOpen) {
+      return;
+    }
+    if (event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    const rect = this.elements.mapInteractive.getBoundingClientRect();
+    this.pointerMoveData = {
+      startX: event.clientX,
+      startY: event.clientY,
+      rect,
+      startCoords: { ...this.state.coords },
+    };
+    this.elements.mapInteractive.setPointerCapture(event.pointerId);
+    this.elements.mapInteractive.classList.add("is-dragging");
+  }
+
+  handlePointerMove(event) {
+    if (!this.isOpen || !this.pointerMoveData) {
+      return;
+    }
+    const { startX, startY, rect, startCoords } = this.pointerMoveData;
+    const deltaX = event.clientX - startX;
+    const deltaY = event.clientY - startY;
+    const degPerPxLng = (2 * MAP_DELTA) / rect.width;
+    const degPerPxLat = (2 * MAP_DELTA) / rect.height;
+    const newLng = startCoords.lng + deltaX * degPerPxLng;
+    const newLat = startCoords.lat - deltaY * degPerPxLat;
+    this.updateCoords(newLat, newLng);
+  }
+
+  stopPointerMove(event) {
+    if (!this.pointerMoveData) {
+      return;
+    }
+    if (
+      event.pointerId &&
+      this.elements.mapInteractive.hasPointerCapture(event.pointerId)
+    ) {
+      this.elements.mapInteractive.releasePointerCapture(event.pointerId);
+    }
+    this.elements.mapInteractive.classList.remove("is-dragging");
+    this.pointerMoveData = null;
+  }
+
+  moveCoords(deltaLat, deltaLng) {
+    const newLat = this.state.coords.lat + deltaLat;
+    const newLng = this.state.coords.lng + deltaLng;
+    this.updateCoords(newLat, newLng);
+  }
+
+  updateCoords(lat, lng) {
+    this.state.coords = {
+      lat: clamp(lat, -90, 90),
+      lng: clamp(lng, -180, 180),
+    };
+    this.state.hasCustomLocation = true;
+    this.updateMap();
+    this.updateCoordSummary();
+    this.updateRawCoords();
+    this.validateLocation();
+    this.setDirty();
+  }
+
+  toggleRawCoords() {
+    this.state.showRawCoords = !this.state.showRawCoords;
+    this.updateRawCoords();
+  }
+
+  handlePrecisionChange() {
+    const selected = this.elements.precisionRadios.find(
+      (radio) => radio.checked,
+    );
+    if (!selected) {
+      return;
+    }
+    this.state.precision = selected.value;
+    this.updateCoordSummary();
+    this.updatePrivacyWarning();
+    this.setDirty();
+  }
+
+  handleSpeciesInput(event) {
+    this.setDirty();
+    const query = event.target.value.trim().toLowerCase();
+    this.updateSpeciesSuggestions(query);
+  }
+
+  async updateSpeciesSuggestions(query) {
+    await this.loadMushrooms();
+    if (!query) {
+      this.hideSpeciesSuggestions();
+      return;
+    }
+    const matches = this.mushrooms
+      .filter(
+        (item) =>
+          item.name.toLowerCase().includes(query) ||
+          item.latin.toLowerCase().includes(query),
+      )
+      .filter(
+        (item) =>
+          !this.state.species.some((selected) => selected.id === item.id),
+      )
+      .slice(0, 6);
+    this.elements.speciesList.innerHTML = "";
+    this.activeSuggestionIndex = -1;
+    if (!matches.length) {
+      const empty = createElement("li", {
+        className: "ns-combobox-empty",
+        attrs: { role: "presentation" },
+        text: "Aucun résultat",
+      });
+      this.elements.speciesList.appendChild(empty);
+      this.elements.speciesInput.setAttribute("aria-expanded", "true");
+      this.elements.speciesList.hidden = false;
+      return;
+    }
+
+    matches.forEach((item, index) => {
+      const option = createElement("li", {
+        className: "ns-combobox-option",
+        attrs: {
+          role: "option",
+          id: `species-option-${item.id}`,
+          "data-species-id": item.id,
+          "data-species-name": item.name,
+          "data-species-latin": item.latin,
+          "aria-selected": "false",
+        },
+      });
+      option.innerHTML = `<span class="ns-option-name">${item.name}</span><span class="ns-option-latin">${item.latin}</span>`;
+      option.addEventListener("mousedown", (event) => {
+        event.preventDefault();
+        this.selectSpecies(item);
+      });
+      this.elements.speciesList.appendChild(option);
+      if (index === 0) {
+        this.elements.speciesInput.setAttribute(
+          "aria-activedescendant",
+          option.id,
+        );
+        option.classList.add("is-active");
+        option.setAttribute("aria-selected", "true");
+        this.activeSuggestionIndex = 0;
+      }
+    });
+
+    this.elements.speciesInput.setAttribute("aria-expanded", "true");
+    this.elements.speciesList.hidden = false;
+  }
+
+  showSpeciesSuggestions() {
+    if (this.elements.speciesList.children.length > 0) {
+      this.elements.speciesInput.setAttribute("aria-expanded", "true");
+      this.elements.speciesList.hidden = false;
+    }
+  }
+
+  hideSpeciesSuggestions() {
+    this.elements.speciesInput.setAttribute("aria-expanded", "false");
+    this.elements.speciesInput.removeAttribute("aria-activedescendant");
+    this.elements.speciesList.hidden = true;
+  }
+
+  handleSpeciesKeydown(event) {
+    const { key } = event;
+    const options = Array.from(
+      this.elements.speciesList.querySelectorAll("[role='option']"),
+    );
+    if (key === "ArrowDown" || key === "ArrowUp") {
+      event.preventDefault();
+      if (!options.length) {
+        return;
+      }
+      if (this.activeSuggestionIndex === -1) {
+        this.activeSuggestionIndex = 0;
+      } else {
+        const delta = key === "ArrowDown" ? 1 : -1;
+        this.activeSuggestionIndex =
+          (this.activeSuggestionIndex + delta + options.length) %
+          options.length;
+      }
+      options.forEach((option, index) => {
+        if (index === this.activeSuggestionIndex) {
+          option.classList.add("is-active");
+          option.setAttribute("aria-selected", "true");
+          this.elements.speciesInput.setAttribute(
+            "aria-activedescendant",
+            option.id,
+          );
+        } else {
+          option.classList.remove("is-active");
+          option.setAttribute("aria-selected", "false");
+        }
+      });
+    } else if (key === "Enter") {
+      if (
+        this.activeSuggestionIndex >= 0 &&
+        options[this.activeSuggestionIndex]
+      ) {
+        event.preventDefault();
+        const option = options[this.activeSuggestionIndex];
+        const item = {
+          id: option.getAttribute("data-species-id"),
+          name: option.getAttribute("data-species-name"),
+          latin: option.getAttribute("data-species-latin"),
+        };
+        this.selectSpecies(item);
+      }
+    } else if (key === "Escape") {
+      this.hideSpeciesSuggestions();
+    }
+  }
+
+  handleDocumentClick(event) {
+    if (!this.isOpen) {
+      return;
+    }
+    if (
+      !this.elements.speciesList.contains(event.target) &&
+      event.target !== this.elements.speciesInput
+    ) {
+      this.hideSpeciesSuggestions();
+    }
+  }
+
+  selectSpecies(item) {
+    if (this.state.species.some((selected) => selected.id === item.id)) {
+      return;
+    }
+    this.state.species.push(item);
+    this.renderSpeciesChips();
+    this.elements.speciesInput.value = "";
+    this.hideSpeciesSuggestions();
+    this.validateSpecies();
+    this.setDirty();
+  }
+
+  renderSpeciesChips() {
+    this.elements.speciesContainer.innerHTML = "";
+    this.state.species.forEach((item) => {
+      const chip = createElement("div", { className: "ns-chip" });
+      const label = createElement("span", {
+        className: "ns-chip-label",
+        text: item.name,
+      });
+      const removeButton = createElement("button", {
+        className: "ns-chip-remove",
+        attrs: { type: "button", "aria-label": `Retirer ${item.name}` },
+        text: "×",
+      });
+      removeButton.addEventListener("click", () => {
+        this.state.species = this.state.species.filter(
+          (species) => species.id !== item.id,
+        );
+        this.renderSpeciesChips();
+        this.validateSpecies();
+        this.setDirty();
+      });
+      chip.appendChild(label);
+      chip.appendChild(removeButton);
+      this.elements.speciesContainer.appendChild(chip);
+    });
+  }
+
+  clearSpeciesChips() {
+    this.elements.speciesContainer.innerHTML = "";
+  }
+
+  setHarvestShortcut(offsetDays) {
+    const date = new Date();
+    date.setDate(date.getDate() - offsetDays);
+    const formatted = formatDate(date);
+    this.elements.harvestDate.value = formatted;
+    this.state.lastHarvest = formatted;
+    this.validateHarvest();
+    this.setDirty();
+  }
+
+  handleHarvestChange() {
+    const value = this.elements.harvestDate.value;
+    this.state.lastHarvest = value;
+    this.validateHarvest();
+    this.setDirty();
+  }
+
+  validateHarvest() {
+    const value = this.elements.harvestDate.value;
+    if (!value) {
+      this.elements.harvestError.hidden = true;
+      this.elements.harvestDate.removeAttribute("aria-invalid");
+      return true;
+    }
+    const selectedDate = new Date(value);
+    const today = new Date(formatDate(new Date()));
+    if (selectedDate > today) {
+      this.elements.harvestError.textContent =
+        "La date ne peut pas être dans le futur.";
+      this.elements.harvestError.hidden = false;
+      this.elements.harvestDate.setAttribute("aria-invalid", "true");
+      return false;
+    }
+    this.elements.harvestError.hidden = true;
+    this.elements.harvestDate.removeAttribute("aria-invalid");
+    return true;
+  }
+
+  handlePhotosChange(event) {
+    this.setDirty();
+    const files = Array.from(event.target.files || []);
+    const newPhotos = [...this.state.photos];
+    files.forEach((file) => {
+      if (newPhotos.length >= MAX_PHOTOS) {
+        return;
+      }
+      if (!this.validateSinglePhoto(file)) {
+        return;
+      }
+      newPhotos.push(file);
+    });
+    this.state.photos = newPhotos.slice(0, MAX_PHOTOS);
+    this.renderPhotoGrid();
+    this.validatePhotos();
+    this.elements.photosInput.value = "";
+  }
+
+  renderPhotoGrid() {
+    this.clearPhotoGrid();
+    this.state.photos.forEach((file, index) => {
+      const figure = createElement("figure", { className: "ns-photo" });
+      const img = createElement("img", {
+        className: "ns-photo-img",
+        attrs: {
+          src: URL.createObjectURL(file),
+          alt: `${file.name} (${Math.round(file.size / 1024)} Ko)`,
+        },
+      });
+      img.dataset.objectUrl = img.src;
+      const controls = createElement("div", { className: "ns-photo-actions" });
+      const replaceButton = createElement("button", {
+        className: "ns-link-button",
+        attrs: { type: "button" },
+        text: "Remplacer",
+      });
+      const removeButton = createElement("button", {
+        className: "ns-link-button",
+        attrs: { type: "button" },
+        text: "Supprimer",
+      });
+      replaceButton.addEventListener("click", () => this.replacePhoto(index));
+      removeButton.addEventListener("click", () => this.removePhoto(index));
+      controls.appendChild(replaceButton);
+      controls.appendChild(removeButton);
+      figure.appendChild(img);
+      figure.appendChild(controls);
+      this.elements.photoGrid.appendChild(figure);
+    });
+  }
+
+  clearPhotoGrid() {
+    Array.from(
+      this.elements.photoGrid.querySelectorAll("img[data-object-url]"),
+    ).forEach((img) => {
+      if (img.dataset.objectUrl) {
+        URL.revokeObjectURL(img.dataset.objectUrl);
+      }
+    });
+    this.elements.photoGrid.innerHTML = "";
+  }
+
+  replacePhoto(index) {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".jpg,.jpeg,.png,.heic,.heif";
+    input.addEventListener("change", () => {
+      const file = input.files && input.files[0];
+      if (!file) {
+        return;
+      }
+      if (!this.validateSinglePhoto(file)) {
+        return;
+      }
+      this.state.photos[index] = file;
+      this.renderPhotoGrid();
+      this.validatePhotos();
+      this.setDirty();
+    });
+    input.click();
+  }
+
+  removePhoto(index) {
+    this.state.photos.splice(index, 1);
+    this.renderPhotoGrid();
+    this.validatePhotos();
+    this.setDirty();
+  }
+
+  validateSinglePhoto(file) {
+    if (!isAcceptedFileType(file)) {
+      this.elements.photosError.textContent =
+        "Format de fichier non pris en charge.";
+      this.elements.photosError.hidden = false;
+      return false;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      this.elements.photosError.textContent =
+        "Chaque photo doit peser moins de 10 Mo.";
+      this.elements.photosError.hidden = false;
+      return false;
+    }
+    return true;
+  }
+
+  validatePhotos() {
+    if (this.state.photos.length > MAX_PHOTOS) {
+      this.elements.photosError.textContent = `Limité à ${MAX_PHOTOS} photos.`;
+      this.elements.photosError.hidden = false;
+      return false;
+    }
+    for (const file of this.state.photos) {
+      if (!this.validateSinglePhoto(file)) {
+        return false;
+      }
+    }
+    this.elements.photosError.hidden = true;
+    return true;
+  }
+
+  togglePrivacy() {
+    this.state.isPublic = !this.state.isPublic;
+    this.updatePrivacyUI();
+    this.updatePrivacyWarning();
+    this.validatePublicConsent();
+    this.setDirty();
+  }
+
+  updatePrivacyUI() {
+    const { isPublic } = this.state;
+    this.elements.privacyToggle.setAttribute(
+      "aria-checked",
+      isPublic ? "true" : "false",
+    );
+    this.elements.privacyToggle.classList.toggle("is-active", isPublic);
+    this.elements.privacyStatus.textContent = isPublic ? "Public" : "Privé";
+    this.elements.publicConsentWrapper.hidden = !isPublic;
+    this.elements.publicConsent.required = isPublic;
+    if (!isPublic) {
+      this.elements.publicConsent.checked = false;
+      this.state.publicConsent = false;
+    }
+  }
+
+  updatePrivacyWarning() {
+    if (this.state.isPublic && this.state.precision === "exact") {
+      this.elements.precisionAlert.hidden = false;
+    } else {
+      this.elements.precisionAlert.hidden = true;
+    }
+  }
+
+  handlePublicConsentChange() {
+    this.state.publicConsent = this.elements.publicConsent.checked;
+    this.validatePublicConsent();
+    this.setDirty();
+  }
+
+  validatePublicConsent() {
+    if (!this.state.isPublic) {
+      this.elements.publicError.hidden = true;
+      this.elements.publicConsent.removeAttribute("aria-invalid");
+      return true;
+    }
+    if (this.state.publicConsent) {
+      this.elements.publicError.hidden = true;
+      this.elements.publicConsent.removeAttribute("aria-invalid");
+      return true;
+    }
+    this.elements.publicError.textContent =
+      "Veuillez confirmer la mise en public.";
+    this.elements.publicError.hidden = false;
+    this.elements.publicConsent.setAttribute("aria-invalid", "true");
+    return false;
+  }
+
+  validateName() {
+    const value = this.elements.nameInput.value.trim();
+    if (!value) {
+      this.elements.nameError.textContent = "Indiquez un nom de coin.";
+      this.elements.nameError.hidden = false;
+      this.elements.nameInput.setAttribute("aria-invalid", "true");
+      this.elements.nameInput.setAttribute(
+        "aria-describedby",
+        "spot-name-help spot-name-error",
+      );
+      return false;
+    }
+    this.elements.nameError.hidden = true;
+    this.elements.nameInput.removeAttribute("aria-invalid");
+    this.elements.nameInput.setAttribute("aria-describedby", "spot-name-help");
+    return true;
+  }
+
+  validateLocation() {
+    if (!this.state.hasCustomLocation) {
+      this.elements.mapError.textContent =
+        "Déplacez l’épingle pour valider l’emplacement.";
+      this.elements.mapError.hidden = false;
+      this.elements.mapField.setAttribute(
+        "aria-describedby",
+        `${this.baseMapDescription} spot-location-error`,
+      );
+      this.elements.mapField.setAttribute("aria-invalid", "true");
+      return false;
+    }
+    this.elements.mapError.hidden = true;
+    this.elements.mapField.setAttribute(
+      "aria-describedby",
+      this.baseMapDescription,
+    );
+    this.elements.mapField.removeAttribute("aria-invalid");
+    return true;
+  }
+
+  validateSpecies() {
+    if (!this.state.species.length) {
+      this.elements.speciesError.textContent =
+        "Sélectionnez au moins une espèce.";
+      this.elements.speciesError.hidden = false;
+      this.elements.speciesInput.setAttribute("aria-invalid", "true");
+      this.elements.speciesInput.setAttribute(
+        "aria-describedby",
+        "spot-species-help spot-species-error",
+      );
+      return false;
+    }
+    this.elements.speciesError.hidden = true;
+    this.elements.speciesInput.removeAttribute("aria-invalid");
+    this.elements.speciesInput.setAttribute(
+      "aria-describedby",
+      "spot-species-help",
+    );
+    return true;
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    if (this.isSubmitting) {
+      return;
+    }
+    const validName = this.validateName();
+    const validLocation = this.validateLocation();
+    const validSpecies = this.validateSpecies();
+    const validHarvest = this.validateHarvest();
+    const validPhotos = this.validatePhotos();
+    const validConsent = this.validatePublicConsent();
+
+    const isValid =
+      validName &&
+      validLocation &&
+      validSpecies &&
+      validHarvest &&
+      validPhotos &&
+      validConsent;
+
+    if (!isValid) {
+      this.setStatus("Certaines informations doivent être corrigées.");
+      this.updateSubmitState();
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.updateSubmitState();
+
+    setTimeout(() => {
+      this.setStatus("Coin enregistré (simulation).");
+      this.isDirty = false;
+      this.isSubmitting = false;
+      try {
+        window.localStorage.removeItem("mesureconvert-new-spot-draft");
+      } catch (error) {
+        console.warn("Impossible de nettoyer le brouillon", error);
+      }
+      this.updateSubmitState();
+      this.close();
+    }, 800);
+  }
+
+  updateSubmitState() {
+    const isDisabled =
+      this.isSubmitting ||
+      !this.state.hasCustomLocation ||
+      !this.elements.nameInput.value.trim() ||
+      !this.state.species.length ||
+      (this.state.isPublic && !this.state.publicConsent);
+    this.elements.submitButton.disabled = isDisabled;
+    this.elements.submitButton.classList.toggle(
+      "is-loading",
+      this.isSubmitting,
+    );
+    if (this.isSubmitting) {
+      this.elements.submitButton.setAttribute("aria-busy", "true");
+    } else {
+      this.elements.submitButton.removeAttribute("aria-busy");
+    }
+  }
+
+  handleKeydown(event) {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      if (!this.confirmDialog.hidden) {
+        this.closeConfirm();
+      } else {
+        this.requestClose();
+      }
+      return;
+    }
+    if (event.key === "Tab") {
+      this.trapFocus(event);
+    }
+  }
+
+  trapFocus(event) {
+    const root = this.confirmDialog.hidden ? this.modal : this.confirmDialog;
+    const focusable = getFocusableElements(root).filter(
+      (element) => element.offsetParent !== null,
+    );
+    if (!focusable.length) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  openConfirm() {
+    this.confirmDialog.hidden = false;
+    this.modal.setAttribute("aria-hidden", "true");
+    this.focusTrapRoot = this.confirmDialog;
+    const buttons = getFocusableElements(this.confirmDialog);
+    if (buttons.length) {
+      buttons[0].focus();
+    }
+  }
+
+  closeConfirm() {
+    this.confirmDialog.hidden = true;
+    this.modal.removeAttribute("aria-hidden");
+    this.focusTrapRoot = this.modal;
+    this.elements.nameInput.focus();
+  }
+
+  saveDraftAndClose() {
+    const payload = {
+      name: this.elements.nameInput.value.trim(),
+      coords: this.state.coords,
+      precision: this.state.precision,
+      species: this.state.species,
+      lastHarvest: this.state.lastHarvest,
+      rating: this.state.rating,
+      isPublic: this.state.isPublic,
+      consent: this.state.publicConsent,
+      hasCustomLocation: this.state.hasCustomLocation,
+    };
+    try {
+      window.localStorage.setItem(
+        "mesureconvert-new-spot-draft",
+        JSON.stringify(payload),
+      );
+      this.setStatus("Brouillon enregistré localement.");
+    } catch (error) {
+      console.warn("Impossible d'enregistrer le brouillon", error);
+      this.setStatus("Impossible d’enregistrer le brouillon.");
+    }
+    this.forceClose();
+  }
+
+  setDirty() {
+    if (!this.isDirty) {
+      this.isDirty = true;
+    }
+    this.updateSubmitState();
+  }
+}
+
+export function initNewSpotModal() {
+  const trigger = document.getElementById("open-new-spot");
+  const container = document.getElementById("new-spot-modal-root");
+  if (!trigger || !container) {
+    return;
+  }
+  new NewSpotModal(trigger, container);
+}

--- a/src/map.html
+++ b/src/map.html
@@ -1,8 +1,9 @@
 <h1>Carte interactive</h1>
         <p>Affichez une carte centrée sur votre position et vérifiez si la géolocalisation est disponible dans votre navigateur.</p>
         <section class="map-section">
-            <div class="map-actions">
+            <div class="map-actions" aria-live="polite">
                 <button type="button" id="geolocate-button" class="btn">Activer la géolocalisation</button>
+                <button type="button" id="open-new-spot" class="btn btn-secondary" aria-haspopup="dialog" aria-controls="new-spot-modal">Ajouter un coin</button>
                 <p id="map-status" class="map-status" aria-live="polite"></p>
                 <p id="map-error" class="error" role="alert" hidden></p>
             </div>
@@ -11,3 +12,4 @@
             </div>
             <p class="map-caption">La carte s’appuie sur OpenStreetMap et n’envoie aucune donnée personnelle vers nos serveurs.</p>
         </section>
+        <div id="new-spot-modal-root"></div>


### PR DESCRIPTION
## Summary
- build a mobile-first "Ajouter un coin" dialog with guided sections, validation, draft handling and improved map interactions
- add dedicated styles for the modal, focus management, chips, toggle and photo grid to match the MesureConvert palette
- load mushroom taxonomy from a new static dataset and hook the modal into the existing carte page

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b505b4e48329a9a7c5f8103ed013