### PR TITLE
Add responsive coin detail page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,10 @@ Visualisez le site directement sur StackBlitz : https://stackblitz.com/github/to
 - [Accessibilité](accessibilite.html)
 - [Sécurité des données](securite-des-donnees.html)
 - [Plan du site](sitemap.html)
+
+## Mocks champignons
+
+Les composants de la page `coin-detail.html` consomment les données du fichier `data/spot-detail.json`.
+Mettez à jour ce fichier pour ajuster les informations affichées (coin, cueillettes, photos).
+Vérifiez que la structure JSON conserve les clés `spot`, `pickings` et `photos`, et que la page reste conforme après `npm run build`.
+

--- a/data/spot-detail.json
+++ b/data/spot-detail.json
@@ -1,0 +1,204 @@
+{
+  "spot": {
+    "id": "spot-fontainebleau-apremont",
+    "name": "Chênaie de Fontainebleau",
+    "subtitle": "Clairière des Gorges d'Apremont",
+    "city": "Fontainebleau",
+    "address": "Route de la Plaine de la Haute Borne, 77300 Fontainebleau, France",
+    "precision": "approx_100m",
+    "coordinates": {
+      "lat": 48.44562,
+      "lng": 2.63748
+    },
+    "createdAt": "2022-09-18T09:45:00.000Z",
+    "pickingsCount": 18,
+    "lastPicking": {
+      "id": "picking-2024-05-06",
+      "date": "2024-05-06T07:30:00.000Z",
+      "rating": 4.5,
+      "weather": {
+        "icon": "partly-cloudy",
+        "label": "Éclaircies humides"
+      },
+      "species": [
+        {
+          "name": "Cèpe de Bordeaux",
+          "quantity": 6,
+          "unit": "pièces",
+          "weightKg": 1.3
+        },
+        {
+          "name": "Girolle",
+          "quantity": 12,
+          "unit": "pièces",
+          "weightKg": 0.6
+        }
+      ],
+      "totalWeightKg": 1.9,
+      "notes": "Sous-bois humide et mousse abondante à l'ombre des pins.",
+      "temperatureC": 14,
+      "humidity": 82
+    },
+    "activitySeries": [
+      { "date": "2024-04-23", "quantity": 0.4 },
+      { "date": "2024-04-24", "quantity": 0.0 },
+      { "date": "2024-04-25", "quantity": 0.6 },
+      { "date": "2024-04-26", "quantity": 0.8 },
+      { "date": "2024-04-27", "quantity": 1.1 },
+      { "date": "2024-04-28", "quantity": 0.2 },
+      { "date": "2024-04-29", "quantity": 0.0 },
+      { "date": "2024-04-30", "quantity": 0.5 },
+      { "date": "2024-05-01", "quantity": 0.7 },
+      { "date": "2024-05-02", "quantity": 0.9 },
+      { "date": "2024-05-03", "quantity": 0.0 },
+      { "date": "2024-05-04", "quantity": 1.2 },
+      { "date": "2024-05-05", "quantity": 1.0 },
+      { "date": "2024-05-06", "quantity": 1.9 }
+    ]
+  },
+  "pickings": [
+    {
+      "id": "picking-2024-05-06",
+      "date": "2024-05-06T07:30:00.000Z",
+      "rating": 4.5,
+      "species": [
+        { "name": "Cèpe de Bordeaux", "quantity": 6, "unit": "pièces", "weightKg": 1.3 },
+        { "name": "Girolle", "quantity": 12, "unit": "pièces", "weightKg": 0.6 }
+      ],
+      "totalWeightKg": 1.9,
+      "weather": {
+        "icon": "partly-cloudy",
+        "label": "Éclaircies humides"
+      }
+    },
+    {
+      "id": "picking-2024-05-03",
+      "date": "2024-05-03T06:50:00.000Z",
+      "rating": 4.2,
+      "species": [
+        { "name": "Morille conique", "quantity": 9, "unit": "pièces", "weightKg": 0.9 }
+      ],
+      "totalWeightKg": 0.9,
+      "weather": {
+        "icon": "rainy",
+        "label": "Pluie légère"
+      }
+    },
+    {
+      "id": "picking-2024-04-30",
+      "date": "2024-04-30T09:15:00.000Z",
+      "rating": 3.5,
+      "species": [
+        { "name": "Coprin chevelu", "quantity": 15, "unit": "pièces", "weightKg": 0.7 },
+        { "name": "Tricholome de la Saint-Georges", "quantity": 8, "unit": "pièces", "weightKg": 0.5 }
+      ],
+      "totalWeightKg": 1.2,
+      "weather": {
+        "icon": "cloudy",
+        "label": "Ciel couvert"
+      }
+    },
+    {
+      "id": "picking-2024-04-27",
+      "date": "2024-04-27T08:20:00.000Z",
+      "rating": 4.7,
+      "species": [
+        { "name": "Morille blonde", "quantity": 11, "unit": "pièces", "weightKg": 1.1 }
+      ],
+      "totalWeightKg": 1.1,
+      "weather": {
+        "icon": "sunny",
+        "label": "Grand soleil"
+      }
+    },
+    {
+      "id": "picking-2024-04-24",
+      "date": "2024-04-24T10:05:00.000Z",
+      "rating": 3.0,
+      "species": [
+        { "name": "Collybie beurrée", "quantity": 5, "unit": "pièces", "weightKg": 0.3 }
+      ],
+      "totalWeightKg": 0.3,
+      "weather": {
+        "icon": "windy",
+        "label": "Vent d'ouest"
+      }
+    },
+    {
+      "id": "picking-2024-04-22",
+      "date": "2024-04-22T07:55:00.000Z",
+      "rating": 2.5,
+      "species": [
+        { "name": "Marasme des Oréades", "quantity": 20, "unit": "pièces", "weightKg": 0.4 }
+      ],
+      "totalWeightKg": 0.4,
+      "weather": {
+        "icon": "foggy",
+        "label": "Brume matinale"
+      }
+    },
+    {
+      "id": "picking-2024-04-18",
+      "date": "2024-04-18T09:40:00.000Z",
+      "rating": 4.9,
+      "species": [
+        { "name": "Morille conique", "quantity": 13, "unit": "pièces", "weightKg": 1.2 }
+      ],
+      "totalWeightKg": 1.2,
+      "weather": {
+        "icon": "sunny",
+        "label": "Temps clair"
+      }
+    },
+    {
+      "id": "picking-2024-04-14",
+      "date": "2024-04-14T08:10:00.000Z",
+      "rating": 3.8,
+      "species": [
+        { "name": "Tricholome de la Saint-Georges", "quantity": 10, "unit": "pièces", "weightKg": 0.8 }
+      ],
+      "totalWeightKg": 0.8,
+      "weather": {
+        "icon": "partly-cloudy",
+        "label": "Éclaircies"
+      }
+    }
+  ],
+  "photos": [
+    {
+      "id": "photo-01",
+      "src": "https://images.unsplash.com/photo-1471193945509-9ad0617afabf?auto=format&fit=crop&w=800&q=80",
+      "alt": "Sous-bois couvert de mousse avec lumière dorée",
+      "width": 800,
+      "height": 800
+    },
+    {
+      "id": "photo-02",
+      "src": "https://images.unsplash.com/photo-1509021436665-8f07dbf5bf1d?auto=format&fit=crop&w=800&q=80",
+      "alt": "Panier de girolles fraîches",
+      "width": 800,
+      "height": 800
+    },
+    {
+      "id": "photo-03",
+      "src": "https://images.unsplash.com/photo-1501785888041-af3ef285b470?auto=format&fit=crop&w=800&q=80",
+      "alt": "Affleurement rocheux dans la forêt de Fontainebleau",
+      "width": 800,
+      "height": 800
+    },
+    {
+      "id": "photo-04",
+      "src": "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=800&q=80",
+      "alt": "Sentier ombragé avec fougères",
+      "width": 800,
+      "height": 800
+    },
+    {
+      "id": "photo-05",
+      "src": "https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=800&q=80",
+      "alt": "Coupe de cèpes prêts à être cuisinés",
+      "width": 800,
+      "height": 800
+    }
+  ]
+}

--- a/pages.json
+++ b/pages.json
@@ -10,6 +10,11 @@
     "description": "Activez la géolocalisation pour centrer une carte OpenStreetMap sur votre position depuis MesureConvert."
   },
   {
+    "file": "coin-detail.html",
+    "title": "Détail du coin de cueillette | MesureConvert",
+    "description": "Consultez les informations détaillées d’un coin de cueillette : historique, carte, photos et statistiques."
+  },
+  {
     "file": "a-propos.html",
     "title": "À propos - MesureConvert",
     "description": "Découvrez l'objectif et l'équipe derrière MesureConvert."

--- a/src/coin-detail.html
+++ b/src/coin-detail.html
@@ -1,0 +1,16 @@
+<section class="spot-detail" data-spot-detail-root aria-busy="true">
+    <div class="spot-detail__skeleton" aria-hidden="true">
+        <div class="spot-detail__skeleton-breadcrumb skeleton-block"></div>
+        <div class="spot-detail__skeleton-header">
+            <div class="skeleton-block skeleton-block--title"></div>
+            <div class="skeleton-block skeleton-block--subtitle"></div>
+        </div>
+        <div class="spot-detail__skeleton-grid">
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+            <div class="skeleton-card"></div>
+        </div>
+    </div>
+</section>
+<div class="spot-detail__toast-region" data-spot-toast-container aria-live="assertive" aria-atomic="true"></div>
+<script type="module" src="./js/spot-detail/spot-detail-page.js"></script>

--- a/src/css/spot-detail.css
+++ b/src/css/spot-detail.css
@@ -1,0 +1,1038 @@
+:root {
+  --color-primary: #1456e2;
+  --color-text: #0e1116;
+  --color-muted: #edf1f7;
+  --color-border: #d9dde6;
+  --color-subtle: #f6f8fc;
+  --color-error: #f97316;
+  --color-success: #10b981;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.12);
+  --radius-md: 12px;
+  --radius-lg: 16px;
+}
+
+.spot-detail {
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+  color: var(--color-text);
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 1.5rem 1rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .spot-detail {
+    padding: 2rem;
+    gap: 2rem;
+  }
+}
+
+.spot-detail__skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.spot-detail__skeleton-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.skeleton-block,
+.skeleton-card {
+  border-radius: var(--radius-md);
+  background: linear-gradient(90deg, #eceff4 0%, #f7f9fc 50%, #eceff4 100%);
+  background-size: 200% 100%;
+  animation: spot-skeleton 1.6s ease-in-out infinite;
+  min-height: 1rem;
+}
+
+.skeleton-block--title {
+  height: 2rem;
+  width: 70%;
+}
+
+.skeleton-block--subtitle {
+  height: 1.25rem;
+  width: 55%;
+}
+
+.skeleton-card {
+  height: 160px;
+}
+
+@keyframes spot-skeleton {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.spot-detail__breadcrumb {
+  font-size: 0.875rem;
+}
+
+.spot-detail__breadcrumb ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.spot-detail__breadcrumb a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.spot-detail__breadcrumb a:hover,
+.spot-detail__breadcrumb a:focus-visible {
+  text-decoration: underline;
+}
+
+.spot-detail__header {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .spot-detail__header {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 2rem;
+  }
+}
+
+.spot-detail__header-main {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.spot-detail__back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: #ffffff;
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+  min-height: 44px;
+}
+
+.spot-detail__back-button svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.spot-detail__header-titles {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.spot-detail__header h1 {
+  font-size: 2rem;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.spot-detail__subtitle {
+  margin: 0;
+  color: #2b3240;
+  font-size: 1rem;
+}
+
+.spot-detail__actions {
+  display: flex;
+  justify-content: flex-end;
+  position: relative;
+}
+
+.spot-detail__actions-desktop {
+  display: none;
+  gap: 0.5rem;
+}
+
+.spot-detail__actions-mobile {
+  display: inline-flex;
+}
+
+@media (min-width: 768px) {
+  .spot-detail__actions-desktop {
+    display: inline-flex;
+  }
+
+  .spot-detail__actions-mobile {
+    display: none;
+  }
+}
+
+.spot-button {
+  font: inherit;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  min-height: 44px;
+  min-width: 44px;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.spot-button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px var(--color-primary));
+}
+
+.spot-button--primary {
+  background: var(--color-primary);
+  color: #ffffff;
+}
+
+.spot-button--primary:hover {
+  background: #0f46b8;
+}
+
+.spot-button--secondary {
+  background: #ffffff;
+  border-color: var(--color-border);
+  color: inherit;
+}
+
+.spot-button--secondary:hover {
+  border-color: #98a2b3;
+}
+
+.spot-button--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: inherit;
+}
+
+.spot-actions-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  padding: 0.5rem 0;
+  min-width: 220px;
+  z-index: 20;
+}
+
+.spot-actions-menu[hidden] {
+  display: none;
+}
+
+.spot-actions-menu button,
+.spot-actions-menu a {
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.spot-actions-menu button:hover,
+.spot-actions-menu button:focus-visible,
+.spot-actions-menu a:hover,
+.spot-actions-menu a:focus-visible {
+  background: var(--color-muted);
+  outline: none;
+}
+
+.spot-detail__sections {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .spot-detail__sections {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    column-gap: 2rem;
+  }
+}
+
+.spot-section {
+  background: #ffffff;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spot-section h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.spot-section--info,
+.spot-section--map {
+  order: 1;
+}
+
+.spot-section--last,
+.spot-section--history,
+.spot-section--photos,
+.spot-section--note,
+.spot-section--chart,
+.spot-section--activity {
+  order: 2;
+}
+
+@media (min-width: 768px) {
+  .spot-section--info {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .spot-section--map {
+    grid-column: 2;
+    grid-row: 2;
+  }
+
+  .spot-section--last {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .spot-section--history {
+    grid-column: 1;
+    grid-row: 2;
+  }
+
+  .spot-section--photos {
+    grid-column: 1;
+    grid-row: 3;
+  }
+
+  .spot-section--note {
+    grid-column: 1;
+    grid-row: 4;
+  }
+
+  .spot-section--chart {
+    grid-column: 1;
+    grid-row: 5;
+  }
+
+  .spot-section--activity {
+    grid-column: 1;
+    grid-row: 6;
+  }
+}
+
+.spot-info__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-info__location {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.spot-info__coords {
+  font-size: 0.95rem;
+  color: #2b3240;
+}
+
+.spot-info__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem 1.5rem;
+  margin: 0;
+}
+
+.spot-info__meta dt {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #2b3240;
+}
+
+.spot-info__meta dd {
+  margin: 0.25rem 0 0;
+  font-size: 1rem;
+}
+
+.spot-map__frame {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-muted);
+  min-height: 220px;
+}
+
+.spot-map__frame iframe {
+  width: 100%;
+  min-height: 220px;
+  border: 0;
+}
+
+.spot-map__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.spot-last-picking__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.spot-last-picking__date {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.spot-badge-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.spot-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  background: var(--color-muted);
+  color: inherit;
+  font-size: 0.9rem;
+}
+
+.spot-last-picking__meta {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.spot-last-picking__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.spot-weather {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #2b3240;
+}
+
+.spot-history__filters {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spot-filters__row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-filters__inputs {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.spot-input,
+.spot-select {
+  font: inherit;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  min-height: 44px;
+}
+
+.spot-input:focus-visible,
+.spot-select:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px var(--color-primary));
+  border-color: transparent;
+}
+
+.spot-filters__error {
+  color: var(--color-error);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.spot-history__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spot-history__item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.spot-history__item--empty {
+  text-align: center;
+  color: #2b3240;
+  font-style: italic;
+}
+
+@media (min-width: 600px) {
+  .spot-history__item {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+}
+
+.spot-history__item h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1.2rem;
+}
+
+.spot-history__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.spot-history__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+@media (min-width: 600px) {
+  .spot-history__actions {
+    align-items: flex-end;
+  }
+}
+
+.spot-pagination {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.spot-pagination__button {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border);
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.spot-pagination__button[aria-current="page"] {
+  background: var(--color-primary);
+  color: #ffffff;
+  border-color: var(--color-primary);
+}
+
+.spot-pagination__button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px var(--color-primary));
+}
+
+.spot-photos__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-photos__upload {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.spot-photos__constraints {
+  font-size: 0.9rem;
+  color: #2b3240;
+  margin: 0;
+}
+
+.spot-photos__error {
+  color: var(--color-error);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.spot-photos__grid {
+  .spot-photos__grid > .spot-empty-state {
+    grid-column: 1 / -1;
+    align-items: center;
+    text-align: center;
+  }
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
+}
+
+.spot-photo-card {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background: var(--color-subtle);
+  aspect-ratio: 1 / 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.spot-photo-card__open {
+  all: unset;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
+  display: block;
+}
+
+.spot-photo-card__open:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px var(--color-primary));
+}
+
+.spot-photo-card__open img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.spot-photo-card__controls {
+  position: absolute;
+  inset: auto 0 0 0;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  padding: 0.5rem;
+  background: linear-gradient(
+    180deg,
+    rgba(14, 17, 22, 0) 0%,
+    rgba(14, 17, 22, 0.6) 100%
+  );
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.spot-photo-card:hover .spot-photo-card__controls,
+.spot-photo-card:focus-within .spot-photo-card__controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.spot-photo-card__controls .spot-button {
+  padding: 0.25rem 0.75rem;
+  min-height: 36px;
+  font-size: 0.85rem;
+  color: #ffffff;
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(14, 17, 22, 0.55);
+}
+
+.spot-photo-card__controls .spot-button:hover {
+  background: rgba(14, 17, 22, 0.75);
+}
+
+.spot-note__info {
+  margin: 0;
+  color: #2b3240;
+  font-size: 0.95rem;
+}
+
+.spot-note__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-note__description {
+  margin: 0;
+  color: #2b3240;
+  font-size: 0.95rem;
+}
+
+.spot-rating-input {
+  display: inline-flex;
+  gap: 0.5rem;
+}
+
+.spot-rating-input input {
+  position: absolute;
+  opacity: 0;
+}
+
+.spot-rating-input label {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--color-border);
+  background: #ffffff;
+  cursor: pointer;
+}
+
+.spot-rating-input label svg {
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: var(--color-primary);
+  stroke-width: 1.5px;
+}
+
+.spot-rating-input input:checked + label {
+  background: var(--color-primary);
+}
+
+.spot-rating-input input:checked + label svg {
+  stroke: #ffffff;
+  fill: #ffffff;
+}
+
+.spot-rating-input label:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px var(--color-primary));
+}
+
+.spot-rating-tooltip {
+  position: absolute;
+  top: -2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0e1116;
+  color: #ffffff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.spot-rating-input:focus-within + .spot-rating-tooltip,
+.spot-rating-input:hover + .spot-rating-tooltip {
+  opacity: 1;
+}
+
+.spot-rating-tooltip[aria-hidden="true"] {
+  display: block;
+}
+
+.spot-rating-display {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.spot-rating-display svg {
+  width: 1rem;
+  height: 1rem;
+  fill: var(--color-primary);
+}
+
+.spot-chart {
+  position: relative;
+}
+
+.spot-chart svg {
+  width: 100%;
+  height: auto;
+}
+
+.spot-chart__tooltip {
+  position: absolute;
+  background: #0e1116;
+  color: #ffffff;
+  padding: 0.35rem 0.5rem;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -120%);
+  transition: opacity 0.15s ease;
+  white-space: nowrap;
+  z-index: 10;
+}
+
+.spot-chart__tooltip[data-visible="true"] {
+  opacity: 1;
+}
+
+.spot-activity-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spot-activity-summary__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.spot-activity-summary__stat {
+  background: var(--color-muted);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+}
+
+.spot-activity-summary__stat dt {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #2b3240;
+}
+
+.spot-activity-summary__stat dd {
+  .spot-activity-summary__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+  margin: 0.5rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.spot-empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-detail__toast-region {
+  position: fixed;
+  left: 50%;
+  bottom: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(90%, 420px);
+  pointer-events: none;
+}
+
+.spot-toast {
+  pointer-events: auto;
+  background: rgba(249, 115, 22, 0.1);
+  border: 1px solid var(--color-error);
+  color: var(--color-text);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.spot-toast__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.spot-modal,
+.spot-drawer,
+.spot-photo-viewer {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  max-width: 100%;
+}
+
+.spot-modal::backdrop,
+.spot-drawer::backdrop,
+.spot-photo-viewer::backdrop {
+  background: rgba(14, 17, 22, 0.45);
+}
+
+.spot-modal__content,
+.spot-photo-viewer__content {
+  padding: 1.5rem;
+  background: #ffffff;
+  border-radius: var(--radius-lg);
+  max-height: 90vh;
+  overflow: auto;
+}
+
+.spot-photo-viewer__image {
+  max-width: 80vw;
+  max-height: 70vh;
+  width: 100%;
+  object-fit: contain;
+}
+
+.spot-modal__header,
+.spot-photo-viewer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.spot-photo-viewer__nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.spot-photo-viewer__controls {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.spot-photo-viewer__caption {
+  margin-top: 1rem;
+  font-size: 0.95rem;
+  text-align: center;
+}
+
+.spot-drawer {
+  width: min(420px, 90vw);
+  margin: 0;
+  inset: 0 0 0 auto;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.spot-drawer__content {
+  background: #ffffff;
+  height: 100%;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.spot-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.spot-drawer__body {
+  flex: 1;
+  overflow: auto;
+}
+
+.spot-drawer__placeholder {
+  background: var(--color-muted);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  color: #2b3240;
+}
+
+.spot-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (min-width: 768px) {
+  .spot-history__filters {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+  }
+
+  .spot-filters__inputs {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+  }
+
+  .spot-history__actions {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+  }
+}
+
+.spot-filters details {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+}
+
+.spot-filters summary {
+  cursor: pointer;
+  font-weight: 600;
+  list-style: none;
+}
+
+@media (min-width: 768px) {
+  .spot-filters details {
+    border: none;
+    padding: 0;
+  }
+
+  .spot-filters summary {
+    display: none;
+  }
+}
+
+.spot-filters__content {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,3 +1,5 @@
+@import "./spot-detail.css";
+
 body {
   margin: 0;
   font-family:

--- a/src/js/spot-detail/components/activity-chart.js
+++ b/src/js/spot-detail/components/activity-chart.js
@@ -1,0 +1,246 @@
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+function formatDateLabel(date) {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "short",
+  }).format(new Date(date));
+}
+
+function formatLongDate(date) {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "long",
+  }).format(new Date(date));
+}
+
+export function createActivityChartSection(series, formatNumber) {
+  const section = document.createElement("section");
+  section.className = "spot-section spot-section--chart";
+  section.setAttribute("aria-labelledby", "spot-activity-chart");
+
+  const heading = document.createElement("h2");
+  heading.id = "spot-activity-chart";
+  heading.textContent = "Cueillettes par jour (dernières 2 semaines)";
+
+  const chartContainer = document.createElement("div");
+  chartContainer.className = "spot-chart";
+
+  const tooltip = document.createElement("div");
+  tooltip.className = "spot-chart__tooltip";
+  chartContainer.appendChild(tooltip);
+
+  const width = 640;
+  const height = 280;
+  const margin = { top: 24, right: 20, bottom: 48, left: 48 };
+
+  const maxQuantity = Math.max(...series.map((item) => item.quantity), 1);
+  const pointCount = series.length;
+  const stepX =
+    (width - margin.left - margin.right) / Math.max(pointCount - 1, 1);
+
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+  const title = document.createElementNS(SVG_NS, "title");
+  const titleId = `spot-chart-title-${Math.random().toString(36).slice(2)}`;
+  title.id = titleId;
+  title.textContent = heading.textContent;
+  svg.appendChild(title);
+
+  const summaryData = (() => {
+    const first = series[0];
+    const last = series[series.length - 1];
+    const maxEntry = series.reduce(
+      (acc, item) => (item.quantity > acc.quantity ? item : acc),
+      series[0],
+    );
+    const delta = last.quantity - first.quantity;
+    let trend = "Activité stable.";
+    if (delta > 0.2) {
+      trend = "Activité en hausse sur la période analysée.";
+    } else if (delta < -0.2) {
+      trend = "Activité en baisse sur la période analysée.";
+    }
+    return {
+      trend,
+      maxEntry,
+    };
+  })();
+
+  const desc = document.createElementNS(SVG_NS, "desc");
+  const descId = `spot-chart-desc-${Math.random().toString(36).slice(2)}`;
+  desc.id = descId;
+  desc.textContent = `${summaryData.trend} Pic observé le ${formatLongDate(summaryData.maxEntry.date)} avec ${formatNumber(
+    summaryData.maxEntry.quantity,
+  )} kg.`;
+  svg.appendChild(desc);
+
+  const srSummary = document.createElement("p");
+  const summaryId = `spot-chart-summary-${Math.random().toString(36).slice(2)}`;
+  srSummary.id = summaryId;
+  srSummary.className = "spot-sr-only";
+  srSummary.textContent = desc.textContent;
+
+  svg.setAttribute("role", "img");
+  svg.setAttribute("aria-labelledby", `${titleId} ${descId}`);
+  svg.setAttribute("aria-describedby", summaryId);
+
+  const axisGroup = document.createElementNS(SVG_NS, "g");
+  axisGroup.setAttribute("fill", "none");
+  axisGroup.setAttribute("stroke", "#d9dde6");
+  axisGroup.setAttribute("stroke-width", "1");
+
+  const xAxis = document.createElementNS(SVG_NS, "line");
+  xAxis.setAttribute("x1", margin.left);
+  xAxis.setAttribute("x2", width - margin.right);
+  xAxis.setAttribute("y1", height - margin.bottom);
+  xAxis.setAttribute("y2", height - margin.bottom);
+  axisGroup.appendChild(xAxis);
+
+  const yAxis = document.createElementNS(SVG_NS, "line");
+  yAxis.setAttribute("x1", margin.left);
+  yAxis.setAttribute("x2", margin.left);
+  yAxis.setAttribute("y1", margin.top);
+  yAxis.setAttribute("y2", height - margin.bottom);
+  axisGroup.appendChild(yAxis);
+
+  svg.appendChild(axisGroup);
+
+  const labelsGroup = document.createElementNS(SVG_NS, "g");
+
+  series.forEach((item, index) => {
+    const x = margin.left + index * stepX;
+    if (index === 0 || index === series.length - 1 || index % 3 === 0) {
+      const label = document.createElementNS(SVG_NS, "text");
+      label.setAttribute("x", x);
+      label.setAttribute("y", height - margin.bottom + 24);
+      label.setAttribute("text-anchor", "middle");
+      label.setAttribute("fill", "#2b3240");
+      label.setAttribute("font-size", "12");
+      label.textContent = formatDateLabel(item.date);
+      labelsGroup.appendChild(label);
+    }
+  });
+
+  for (let y = 0; y <= 4; y += 1) {
+    const value = (maxQuantity / 4) * y;
+    const yPos =
+      height -
+      margin.bottom -
+      (value / maxQuantity) * (height - margin.top - margin.bottom);
+    const gridLine = document.createElementNS(SVG_NS, "line");
+    gridLine.setAttribute("x1", margin.left);
+    gridLine.setAttribute("x2", width - margin.right);
+    gridLine.setAttribute("y1", yPos);
+    gridLine.setAttribute("y2", yPos);
+    gridLine.setAttribute("stroke", "rgba(152, 162, 179, 0.3)");
+    gridLine.setAttribute("stroke-dasharray", "4 4");
+    svg.appendChild(gridLine);
+
+    const valueLabel = document.createElementNS(SVG_NS, "text");
+    valueLabel.setAttribute("x", margin.left - 12);
+    valueLabel.setAttribute("y", yPos + 4);
+    valueLabel.setAttribute("text-anchor", "end");
+    valueLabel.setAttribute("fill", "#2b3240");
+    valueLabel.setAttribute("font-size", "12");
+    valueLabel.textContent = formatNumber(value);
+    labelsGroup.appendChild(valueLabel);
+  }
+
+  svg.appendChild(labelsGroup);
+
+  const linePath = document.createElementNS(SVG_NS, "path");
+  const pathD = series
+    .map((item, index) => {
+      const x = margin.left + index * stepX;
+      const y =
+        height -
+        margin.bottom -
+        (item.quantity / maxQuantity) * (height - margin.top - margin.bottom);
+      return `${index === 0 ? "M" : "L"}${x} ${y}`;
+    })
+    .join(" ");
+
+  linePath.setAttribute("d", pathD);
+  linePath.setAttribute("fill", "none");
+  linePath.setAttribute("stroke", "var(--color-primary)");
+  linePath.setAttribute("stroke-width", "2");
+  linePath.setAttribute("stroke-linecap", "round");
+  svg.appendChild(linePath);
+
+  const pointGroup = document.createElementNS(SVG_NS, "g");
+
+  const handleFocus = (event) => {
+    const target = event.target;
+    const index = Number.parseInt(target.getAttribute("data-index"), 10);
+    const item = series[index];
+    if (!item) {
+      return;
+    }
+    const rect = chartContainer.getBoundingClientRect();
+    tooltip.setAttribute("data-visible", "true");
+    tooltip.textContent = `${formatLongDate(item.date)} · ${formatNumber(item.quantity)} kg`;
+    tooltip.style.left = `${target.getBoundingClientRect().left - rect.left}px`;
+    tooltip.style.top = `${target.getBoundingClientRect().top - rect.top - 12}px`;
+  };
+
+  const hideTooltip = () => {
+    tooltip.removeAttribute("data-visible");
+  };
+
+  const focusPoint = (currentIndex, delta) => {
+    const nextIndex = currentIndex + delta;
+    const nextCircle = pointGroup.querySelector(
+      `circle[data-index="${nextIndex}"]`,
+    );
+    if (nextCircle) {
+      nextCircle.focus();
+    }
+  };
+
+  series.forEach((item, index) => {
+    const x = margin.left + index * stepX;
+    const y =
+      height -
+      margin.bottom -
+      (item.quantity / maxQuantity) * (height - margin.top - margin.bottom);
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("cx", x);
+    circle.setAttribute("cy", y);
+    circle.setAttribute("r", "5");
+    circle.setAttribute("fill", "#ffffff");
+    circle.setAttribute("stroke", "var(--color-primary)");
+    circle.setAttribute("stroke-width", "2");
+    circle.setAttribute("tabindex", "0");
+    circle.setAttribute("data-index", String(index));
+    circle.setAttribute(
+      "aria-label",
+      `${formatLongDate(item.date)} : ${formatNumber(item.quantity)} kilogrammes récoltés`,
+    );
+
+    circle.addEventListener("focus", handleFocus);
+    circle.addEventListener("mouseenter", handleFocus);
+    circle.addEventListener("blur", hideTooltip);
+    circle.addEventListener("mouseleave", hideTooltip);
+    circle.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        focusPoint(index, -1);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        focusPoint(index, 1);
+      }
+    });
+
+    pointGroup.appendChild(circle);
+  });
+
+  svg.appendChild(pointGroup);
+
+  chartContainer.appendChild(svg);
+  chartContainer.appendChild(srSummary);
+
+  section.append(heading, chartContainer);
+  return section;
+}

--- a/src/js/spot-detail/components/activity-header.js
+++ b/src/js/spot-detail/components/activity-header.js
@@ -1,0 +1,227 @@
+function createActionButton(label, variant = "secondary") {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = `spot-button spot-button--${variant}`;
+  button.textContent = label;
+  return button;
+}
+
+export function createActivityHeader({
+  spot,
+  onBack,
+  onEdit,
+  onDelete,
+  onAddPicking,
+  onAddPhoto,
+  mapUrl,
+  showToast,
+}) {
+  const header = document.createElement("header");
+  header.className = "spot-detail__header";
+
+  const main = document.createElement("div");
+  main.className = "spot-detail__header-main";
+
+  const backButton = document.createElement("button");
+  backButton.type = "button";
+  backButton.className = "spot-detail__back-button";
+  backButton.setAttribute("aria-label", "Retour vers la carte");
+  backButton.innerHTML = `
+    <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+      <path d="M15 5l-7 7 7 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" />
+    </svg>
+    <span>Retour</span>
+  `;
+
+  backButton.addEventListener("click", () => {
+    if (typeof onBack === "function") {
+      onBack();
+      return;
+    }
+    if (window.history.length > 1) {
+      window.history.back();
+    } else {
+      window.location.href = "map.html";
+    }
+  });
+
+  const titles = document.createElement("div");
+  titles.className = "spot-detail__header-titles";
+
+  const title = document.createElement("h1");
+  title.textContent = spot.name;
+  titles.appendChild(title);
+
+  if (spot.subtitle || spot.city) {
+    const subtitle = document.createElement("p");
+    subtitle.className = "spot-detail__subtitle";
+    if (spot.subtitle && spot.city) {
+      subtitle.textContent = `${spot.city} · ${spot.subtitle}`;
+    } else {
+      subtitle.textContent = spot.subtitle || spot.city;
+    }
+    titles.appendChild(subtitle);
+  }
+
+  main.append(backButton, titles);
+
+  const actionsWrapper = document.createElement("div");
+  actionsWrapper.className = "spot-detail__actions";
+
+  const desktopActions = document.createElement("div");
+  desktopActions.className = "spot-detail__actions-desktop";
+
+  const editButton = createActionButton("Éditer");
+  editButton.addEventListener("click", () => {
+    if (typeof onEdit === "function") {
+      onEdit();
+    } else if (showToast) {
+      showToast(
+        "La modification du coin n'est pas disponible dans cette démo.",
+      );
+    }
+  });
+
+  const deleteButton = createActionButton("Supprimer");
+  deleteButton.addEventListener("click", () => {
+    if (typeof onDelete === "function") {
+      onDelete();
+    } else if (showToast) {
+      showToast("Suppression désactivée sur cet aperçu.");
+    }
+  });
+
+  const addPickingButton = createActionButton(
+    "Ajouter une cueillette",
+    "primary",
+  );
+  addPickingButton.addEventListener("click", (event) => {
+    if (typeof onAddPicking === "function") {
+      onAddPicking(event.currentTarget);
+    }
+  });
+
+  const addPhotoButton = createActionButton("Ajouter une photo");
+  addPhotoButton.addEventListener("click", (event) => {
+    if (typeof onAddPhoto === "function") {
+      onAddPhoto(event.currentTarget);
+    }
+  });
+
+  const mapLink = document.createElement("a");
+  mapLink.className = "spot-button spot-button--secondary";
+  mapLink.href = mapUrl;
+  mapLink.textContent = "Ouvrir sur la carte";
+  mapLink.setAttribute("aria-label", "Ouvrir ce coin sur la carte");
+
+  desktopActions.append(
+    editButton,
+    deleteButton,
+    addPickingButton,
+    addPhotoButton,
+    mapLink,
+  );
+
+  const mobileActions = document.createElement("div");
+  mobileActions.className = "spot-detail__actions-mobile";
+
+  const actionsToggle = document.createElement("button");
+  actionsToggle.type = "button";
+  actionsToggle.className = "spot-button spot-button--secondary";
+  actionsToggle.textContent = "Actions";
+  actionsToggle.setAttribute("aria-haspopup", "true");
+  actionsToggle.setAttribute("aria-expanded", "false");
+
+  const menu = document.createElement("div");
+  menu.className = "spot-actions-menu";
+  menu.setAttribute("role", "menu");
+  menu.hidden = true;
+
+  const menuItems = [
+    { label: "Éditer", handler: () => editButton.click() },
+    { label: "Supprimer", handler: () => deleteButton.click() },
+    {
+      label: "Ajouter une cueillette",
+      handler: () => addPickingButton.click(),
+    },
+    { label: "Ajouter une photo", handler: () => addPhotoButton.click() },
+  ];
+
+  menuItems.forEach(({ label, handler }) => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.textContent = label;
+    item.setAttribute("role", "menuitem");
+    item.addEventListener("click", () => {
+      handler();
+      closeMenu();
+    });
+    menu.appendChild(item);
+  });
+
+  const menuLink = document.createElement("a");
+  menuLink.href = mapUrl;
+  menuLink.textContent = "Ouvrir sur la carte";
+  menuLink.setAttribute("role", "menuitem");
+  menuLink.addEventListener("click", () => {
+    closeMenu();
+  });
+  menu.appendChild(menuLink);
+
+  const closeMenu = () => {
+    menu.hidden = true;
+    actionsToggle.setAttribute("aria-expanded", "false");
+  };
+
+  const openMenu = () => {
+    menu.hidden = false;
+    actionsToggle.setAttribute("aria-expanded", "true");
+    const firstItem = menu.querySelector('[role="menuitem"]');
+    if (firstItem) {
+      firstItem.focus();
+    }
+  };
+
+  actionsToggle.addEventListener("click", () => {
+    if (menu.hidden) {
+      openMenu();
+    } else {
+      closeMenu();
+    }
+  });
+
+  actionsToggle.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowDown" && menu.hidden) {
+      event.preventDefault();
+      openMenu();
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (
+      !menu.hidden &&
+      !menu.contains(event.target) &&
+      event.target !== actionsToggle
+    ) {
+      closeMenu();
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !menu.hidden) {
+      closeMenu();
+      actionsToggle.focus();
+    }
+  });
+
+  mobileActions.append(actionsToggle, menu);
+
+  actionsWrapper.append(desktopActions, mobileActions);
+  header.append(main, actionsWrapper);
+  return {
+    element: header,
+    focusAddPhoto: () => addPhotoButton.focus(),
+    triggerAddPhoto: () => addPhotoButton.click(),
+    triggerAddPicking: () => addPickingButton.click(),
+  };
+}

--- a/src/js/spot-detail/components/photos-gallery.js
+++ b/src/js/spot-detail/components/photos-gallery.js
@@ -1,0 +1,390 @@
+const ACCEPTED_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+  "image/heif",
+]);
+const ACCEPTED_EXTENSIONS = new Set(["jpg", "jpeg", "png", "heic"]);
+const MAX_PHOTOS = 8;
+const MAX_SIZE = 10 * 1024 * 1024;
+
+function isValidType(file) {
+  if (ACCEPTED_TYPES.has(file.type)) {
+    return true;
+  }
+  const extension = file.name.split(".").pop()?.toLowerCase() ?? "";
+  return ACCEPTED_EXTENSIONS.has(extension);
+}
+
+function createPhotoCard(photo, index, { onOpen, onReplace, onDelete }) {
+  const card = document.createElement("article");
+  card.className = "spot-photo-card";
+
+  const openButton = document.createElement("button");
+  openButton.type = "button";
+  openButton.className = "spot-photo-card__open";
+  openButton.setAttribute("aria-label", `${photo.alt} – ouvrir`);
+
+  const img = document.createElement("img");
+  img.src = photo.src;
+  img.alt = photo.alt;
+  img.width = photo.width || 400;
+  img.height = photo.height || 400;
+
+  openButton.appendChild(img);
+  openButton.addEventListener("click", () => onOpen(index, openButton));
+
+  const controls = document.createElement("div");
+  controls.className = "spot-photo-card__controls";
+
+  const replaceButton = document.createElement("button");
+  replaceButton.type = "button";
+  replaceButton.className = "spot-button spot-button--ghost";
+  replaceButton.textContent = "Remplacer";
+  replaceButton.addEventListener("click", () => onReplace(photo.id));
+  replaceButton.setAttribute("aria-label", `Remplacer ${photo.alt}`);
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "spot-button spot-button--ghost";
+  deleteButton.textContent = "Supprimer";
+  deleteButton.setAttribute("aria-label", `Supprimer ${photo.alt}`);
+  deleteButton.addEventListener("click", () => onDelete(photo.id));
+
+  controls.append(replaceButton, deleteButton);
+  card.append(openButton, controls);
+  return card;
+}
+
+function createViewer() {
+  const dialog = document.createElement("dialog");
+  dialog.className = "spot-photo-viewer";
+  dialog.innerHTML = `
+    <div class="spot-photo-viewer__content">
+      <div class="spot-photo-viewer__header">
+        <h2 class="spot-photo-viewer__title">Visionneuse</h2>
+        <button type="button" class="spot-button spot-button--secondary" aria-label="Fermer la visionneuse">Fermer</button>
+      </div>
+      <div class="spot-photo-viewer__nav">
+        <button type="button" class="spot-button spot-button--secondary" data-viewer-prev aria-label="Photo précédente">‹</button>
+        <img class="spot-photo-viewer__image" alt="" />
+        <button type="button" class="spot-button spot-button--secondary" data-viewer-next aria-label="Photo suivante">›</button>
+      </div>
+      <div class="spot-photo-viewer__controls">
+        <p class="spot-photo-viewer__caption"></p>
+      </div>
+    </div>
+  `;
+
+  const closeButton = dialog.querySelector(
+    'button[aria-label="Fermer la visionneuse"]',
+  );
+  const prevButton = dialog.querySelector("[data-viewer-prev]");
+  const nextButton = dialog.querySelector("[data-viewer-next]");
+  const image = dialog.querySelector(".spot-photo-viewer__image");
+  const caption = dialog.querySelector(".spot-photo-viewer__caption");
+  const title = dialog.querySelector(".spot-photo-viewer__title");
+
+  let items = [];
+  let currentIndex = 0;
+  let returnFocusTo = null;
+
+  const update = () => {
+    const current = items[currentIndex];
+    if (!current) {
+      return;
+    }
+    image.src = current.src;
+    image.alt = current.alt;
+    caption.textContent = current.alt;
+    title.textContent = `Photo ${currentIndex + 1} sur ${items.length}`;
+    prevButton.disabled = currentIndex === 0;
+    nextButton.disabled = currentIndex === items.length - 1;
+  };
+
+  const close = () => {
+    dialog.close();
+  };
+
+  closeButton.addEventListener("click", close);
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    close();
+  });
+  dialog.addEventListener("close", () => {
+    if (returnFocusTo) {
+      returnFocusTo.focus();
+    }
+  });
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) {
+      close();
+    }
+  });
+
+  const showPrev = () => {
+    if (currentIndex > 0) {
+      currentIndex -= 1;
+      update();
+    }
+  };
+
+  const showNext = () => {
+    if (currentIndex < items.length - 1) {
+      currentIndex += 1;
+      update();
+    }
+  };
+
+  prevButton.addEventListener("click", showPrev);
+  nextButton.addEventListener("click", showNext);
+
+  dialog.addEventListener("keydown", (event) => {
+    if (event.key === "ArrowLeft") {
+      event.preventDefault();
+      showPrev();
+    } else if (event.key === "ArrowRight") {
+      event.preventDefault();
+      showNext();
+    }
+  });
+
+  document.body.appendChild(dialog);
+
+  return {
+    element: dialog,
+    open(newItems, index, trigger) {
+      items = newItems;
+      currentIndex = index;
+      returnFocusTo = trigger;
+      update();
+      dialog.showModal();
+      closeButton.focus();
+    },
+    refresh(newItems) {
+      items = newItems;
+      if (currentIndex >= items.length) {
+        currentIndex = Math.max(0, items.length - 1);
+      }
+      if (dialog.open) {
+        update();
+      }
+    },
+  };
+}
+
+export function createPhotosGallery({ photos, showToast }) {
+  let photoState = photos.map((photo, index) => ({
+    id: photo.id ?? `photo-${index}`,
+    ...photo,
+  }));
+
+  const section = document.createElement("section");
+  section.className = "spot-section spot-section--photos";
+  section.setAttribute("aria-labelledby", "spot-photos");
+
+  const heading = document.createElement("h2");
+  heading.id = "spot-photos";
+  heading.textContent = "Photos";
+
+  const header = document.createElement("div");
+  header.className = "spot-photos__header";
+
+  const uploadWrapper = document.createElement("div");
+  uploadWrapper.className = "spot-photos__upload";
+
+  const addButton = document.createElement("button");
+  addButton.type = "button";
+  addButton.className = "spot-button spot-button--secondary";
+  addButton.textContent = "Ajouter des photos";
+
+  const uploadInput = document.createElement("input");
+  uploadInput.type = "file";
+  uploadInput.multiple = true;
+  uploadInput.accept = ".jpg,.jpeg,.png,.heic";
+  uploadInput.style.display = "none";
+
+  const replaceInput = document.createElement("input");
+  replaceInput.type = "file";
+  replaceInput.accept = ".jpg,.jpeg,.png,.heic";
+  replaceInput.style.display = "none";
+
+  const constraints = document.createElement("p");
+  constraints.className = "spot-photos__constraints";
+  constraints.textContent = "JPG/PNG/HEIC, ≤10 Mo, jusqu’à 8 photos.";
+
+  const errorMessage = document.createElement("p");
+  errorMessage.className = "spot-photos__error";
+  errorMessage.hidden = true;
+  errorMessage.setAttribute("role", "alert");
+
+  const grid = document.createElement("div");
+  grid.className = "spot-photos__grid";
+
+  uploadWrapper.append(
+    addButton,
+    constraints,
+    errorMessage,
+    uploadInput,
+    replaceInput,
+  );
+  header.append(uploadWrapper);
+
+  section.append(heading, header, grid);
+
+  const viewer = createViewer();
+
+  let pendingReplaceId = null;
+
+  const setError = (message) => {
+    if (message) {
+      errorMessage.hidden = false;
+      errorMessage.textContent = message;
+    } else {
+      errorMessage.hidden = true;
+      errorMessage.textContent = "";
+    }
+  };
+
+  const refreshViewer = () => {
+    viewer.refresh(photoState);
+  };
+
+  const render = () => {
+    grid.innerHTML = "";
+    if (photoState.length === 0) {
+      const empty = document.createElement("div");
+      empty.className = "spot-empty-state";
+      const message = document.createElement("p");
+      message.textContent = "Aucune photo pour le moment.";
+      empty.appendChild(message);
+      grid.appendChild(empty);
+      return;
+    }
+
+    photoState.forEach((photo, index) => {
+      const card = createPhotoCard(photo, index, {
+        onOpen: (idx, trigger) => {
+          viewer.open(photoState, idx, trigger);
+        },
+        onReplace: (photoId) => {
+          pendingReplaceId = photoId;
+          replaceInput.click();
+        },
+        onDelete: (photoId) => {
+          photoState = photoState.filter((item) => item.id !== photoId);
+          render();
+          refreshViewer();
+          if (typeof showToast === "function") {
+            showToast("Photo supprimée.");
+          }
+        },
+      });
+      grid.appendChild(card);
+    });
+  };
+
+  const addPhotos = (files) => {
+    if (!files.length) {
+      return;
+    }
+    const availableSlots = MAX_PHOTOS - photoState.length;
+    if (availableSlots <= 0) {
+      setError("Vous avez atteint la limite de 8 photos.");
+      return;
+    }
+
+    const filesArray = Array.from(files).slice(0, availableSlots);
+    const newPhotos = [];
+    let error = "";
+
+    filesArray.forEach((file, index) => {
+      if (file.size > MAX_SIZE) {
+        error = `${file.name} dépasse la taille maximale de 10 Mo.`;
+        return;
+      }
+      if (!isValidType(file)) {
+        error = `${file.name} n’est pas dans un format supporté.`;
+        return;
+      }
+      const objectUrl = URL.createObjectURL(file);
+      newPhotos.push({
+        id: `added-${Date.now()}-${index}`,
+        src: objectUrl,
+        alt: file.name,
+      });
+    });
+
+    if (error) {
+      setError(error);
+    } else {
+      setError("");
+    }
+
+    if (newPhotos.length) {
+      photoState = [...photoState, ...newPhotos];
+      render();
+      refreshViewer();
+      if (typeof showToast === "function") {
+        showToast("Photo ajoutée.");
+      }
+    }
+  };
+
+  const replacePhoto = (file) => {
+    if (!file || !pendingReplaceId) {
+      return;
+    }
+    if (file.size > MAX_SIZE) {
+      setError(`${file.name} dépasse la taille maximale de 10 Mo.`);
+      return;
+    }
+    if (!isValidType(file)) {
+      setError(`${file.name} n’est pas dans un format supporté.`);
+      return;
+    }
+    const objectUrl = URL.createObjectURL(file);
+    photoState = photoState.map((photo) =>
+      photo.id === pendingReplaceId
+        ? { ...photo, src: objectUrl, alt: file.name }
+        : photo,
+    );
+    pendingReplaceId = null;
+    setError("");
+    render();
+    refreshViewer();
+    if (typeof showToast === "function") {
+      showToast("Photo remplacée.");
+    }
+  };
+
+  addButton.addEventListener("click", () => {
+    uploadInput.click();
+  });
+
+  uploadInput.addEventListener("change", () => {
+    addPhotos(uploadInput.files);
+    uploadInput.value = "";
+  });
+
+  replaceInput.addEventListener("change", () => {
+    if (!replaceInput.files.length) {
+      pendingReplaceId = null;
+      return;
+    }
+    replacePhoto(replaceInput.files[0]);
+    replaceInput.value = "";
+  });
+
+  render();
+
+  return {
+    element: section,
+    triggerAdd() {
+      addButton.click();
+    },
+    focusAdd() {
+      addButton.focus();
+    },
+  };
+}

--- a/src/js/spot-detail/components/pickings-list.js
+++ b/src/js/spot-detail/components/pickings-list.js
@@ -1,0 +1,411 @@
+import { createRatingDisplay } from "./rating.js";
+
+const ITEMS_PER_PAGE = 5;
+
+const WEATHER_ICONS = {
+  sunny:
+    '<circle cx="12" cy="12" r="4" stroke="currentColor" stroke-width="1.5" fill="none"></circle><path d="M12 3v2.5M12 18.5V21M4.22 4.22l1.77 1.77M18.01 17.99l1.77 1.77M3 12h2.5M18.5 12H21M4.22 19.78l1.77-1.77M18.01 6.01l1.77-1.77" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"></path>',
+  "partly-cloudy":
+    '<path d="M7 14a4 4 0 01.62-2.16 3 3 0 015.88.66" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"></path><path d="M16 10a4 4 0 013.464 6H9a3 3 0 010-6 4.5 4.5 0 017-3.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"></path>',
+  cloudy:
+    '<path d="M8.5 15H17a3.5 3.5 0 100-7 4.5 4.5 0 10-8.74 2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"></path><path d="M7 12.5a3 3 0 000 6h8.5" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"></path>',
+  rainy:
+    '<path d="M8.5 15H17a3.5 3.5 0 100-7 4.5 4.5 0 10-8.74 2" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round" stroke-linejoin="round"></path><path d="M9 17l-.75 2M12 17l-.75 2M15 17l-.75 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>',
+  windy:
+    '<path d="M4 12h9a2 2 0 100-4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path><path d="M4 16h6a2 2 0 110 4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>',
+  foggy:
+    '<path d="M5 9h14M5 12h10M5 15h14" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"></path>',
+};
+
+function formatDate(date) {
+  return new Intl.DateTimeFormat("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  }).format(new Date(date));
+}
+
+function createSpeciesBadge(species, formatNumber) {
+  const badge = document.createElement("span");
+  badge.className = "spot-badge";
+  const quantity = species.weightKg
+    ? `${formatNumber(species.weightKg)} kg`
+    : `${formatNumber(species.quantity)} ${species.unit}`;
+  badge.textContent = `${species.name} · ${quantity}`;
+  return badge;
+}
+
+function renderWeather(weather) {
+  if (!weather) {
+    const fallback = document.createElement("p");
+    fallback.className = "spot-weather";
+    fallback.textContent = "Météo non renseignée";
+    return fallback;
+  }
+
+  const wrapper = document.createElement("p");
+  wrapper.className = "spot-weather";
+  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  icon.setAttribute("viewBox", "0 0 24 24");
+  icon.setAttribute("aria-hidden", "true");
+  icon.setAttribute("focusable", "false");
+  icon.innerHTML = WEATHER_ICONS[weather.icon] || WEATHER_ICONS.cloudy;
+  wrapper.append(icon, document.createTextNode(weather.label));
+  return wrapper;
+}
+
+function createHistoryItem(picking, formatNumber, showToast) {
+  const item = document.createElement("li");
+  item.className = "spot-history__item";
+
+  const meta = document.createElement("div");
+  meta.className = "spot-history__meta";
+
+  const title = document.createElement("h3");
+  title.textContent = formatDate(picking.date);
+  meta.appendChild(title);
+
+  const speciesList = document.createElement("div");
+  speciesList.className = "spot-badge-list";
+  picking.species.forEach((species) => {
+    speciesList.appendChild(createSpeciesBadge(species, formatNumber));
+  });
+  meta.appendChild(speciesList);
+
+  const weight = document.createElement("p");
+  weight.textContent = `Poids total : ${formatNumber(picking.totalWeightKg)} kg`;
+  meta.appendChild(weight);
+
+  const actions = document.createElement("div");
+  actions.className = "spot-history__actions";
+  actions.appendChild(createRatingDisplay(picking.rating, { size: "compact" }));
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "spot-button spot-button--secondary";
+  button.textContent = "Consulter";
+  button.addEventListener("click", () => {
+    if (showToast) {
+      showToast(
+        "La fiche détaillée de la cueillette sera disponible prochainement.",
+      );
+    }
+  });
+  actions.appendChild(button);
+
+  item.append(meta, actions);
+  return item;
+}
+
+export function createPickingsSections({
+  lastPicking,
+  pickings,
+  formatNumber,
+  onAddPicking,
+  showToast,
+}) {
+  const lastSection = document.createElement("section");
+  lastSection.className = "spot-section spot-section--last";
+  lastSection.setAttribute("aria-labelledby", "spot-last-picking");
+
+  const lastHeading = document.createElement("h2");
+  lastHeading.id = "spot-last-picking";
+  lastHeading.textContent = "Dernière cueillette";
+
+  const header = document.createElement("div");
+  header.className = "spot-last-picking__header";
+
+  const meta = document.createElement("div");
+  meta.className = "spot-last-picking__meta";
+
+  if (lastPicking) {
+    const date = document.createElement("p");
+    date.className = "spot-last-picking__date";
+    date.textContent = formatDate(lastPicking.date);
+    header.append(date);
+    header.appendChild(createRatingDisplay(lastPicking.rating));
+
+    const speciesList = document.createElement("div");
+    speciesList.className = "spot-badge-list";
+    lastPicking.species.forEach((species) => {
+      speciesList.appendChild(createSpeciesBadge(species, formatNumber));
+    });
+
+    const weight = document.createElement("p");
+    weight.textContent = `Total récolté : ${formatNumber(lastPicking.totalWeightKg)} kg`;
+
+    const weather = renderWeather(lastPicking.weather);
+
+    const notes = document.createElement("p");
+    notes.textContent = lastPicking.notes || "Notes non renseignées.";
+
+    meta.append(speciesList, weight, weather, notes);
+  } else {
+    const empty = document.createElement("div");
+    empty.className = "spot-empty-state";
+    const message = document.createElement("p");
+    message.textContent = "Aucune cueillette enregistrée pour le moment.";
+    empty.appendChild(message);
+    meta.appendChild(empty);
+    const info = document.createElement("p");
+    info.className = "spot-last-picking__date";
+    info.textContent = "Aucune cueillette enregistrée.";
+    header.appendChild(info);
+  }
+
+  const actions = document.createElement("div");
+  actions.className = "spot-last-picking__actions";
+
+  const viewAll = document.createElement("button");
+  viewAll.type = "button";
+  viewAll.className = "spot-button spot-button--secondary";
+  viewAll.textContent = "Voir toutes les cueillettes";
+
+  const addButton = document.createElement("button");
+  addButton.type = "button";
+  addButton.className = "spot-button spot-button--secondary";
+  addButton.textContent = "Ajouter une cueillette";
+  addButton.addEventListener("click", (event) => {
+    if (typeof onAddPicking === "function") {
+      onAddPicking(event.currentTarget);
+    }
+  });
+
+  actions.append(viewAll, addButton);
+
+  lastSection.append(lastHeading, header, meta, actions);
+
+  const historySection = document.createElement("section");
+  historySection.className = "spot-section spot-section--history";
+  historySection.tabIndex = -1;
+  historySection.setAttribute("aria-labelledby", "spot-history");
+
+  const historyHeading = document.createElement("h2");
+  historyHeading.id = "spot-history";
+  historyHeading.textContent = "Historique des cueillettes";
+
+  const filtersContainer = document.createElement("div");
+  filtersContainer.className = "spot-history__filters spot-filters";
+
+  const details = document.createElement("details");
+  details.open = true;
+
+  const summary = document.createElement("summary");
+  summary.textContent = "Filtres";
+
+  const content = document.createElement("div");
+  content.className = "spot-filters__content";
+
+  const inputsRow = document.createElement("div");
+  inputsRow.className = "spot-filters__inputs";
+
+  const today = new Date();
+  const todayValue = today.toISOString().split("T")[0];
+
+  const fromGroup = document.createElement("label");
+  fromGroup.textContent = "Du";
+  const fromInput = document.createElement("input");
+  fromInput.type = "date";
+  fromInput.className = "spot-input";
+  fromInput.max = todayValue;
+  fromGroup.appendChild(fromInput);
+
+  const toGroup = document.createElement("label");
+  toGroup.textContent = "Au";
+  const toInput = document.createElement("input");
+  toInput.type = "date";
+  toInput.className = "spot-input";
+  toInput.max = todayValue;
+  toGroup.appendChild(toInput);
+
+  const speciesGroup = document.createElement("label");
+  speciesGroup.textContent = "Espèce";
+  const speciesSelect = document.createElement("select");
+  speciesSelect.className = "spot-select";
+  const defaultOption = document.createElement("option");
+  defaultOption.value = "";
+  defaultOption.textContent = "Toutes les espèces";
+  speciesSelect.appendChild(defaultOption);
+
+  const speciesSet = new Set();
+  pickings.forEach((picking) => {
+    picking.species.forEach((species) => {
+      speciesSet.add(species.name);
+    });
+  });
+
+  Array.from(speciesSet)
+    .sort((a, b) => a.localeCompare(b, "fr"))
+    .forEach((name) => {
+      const option = document.createElement("option");
+      option.value = name;
+      option.textContent = name;
+      speciesSelect.appendChild(option);
+    });
+
+  speciesGroup.appendChild(speciesSelect);
+
+  inputsRow.append(fromGroup, toGroup, speciesGroup);
+  content.appendChild(inputsRow);
+
+  const errorMessage = document.createElement("p");
+  errorMessage.className = "spot-filters__error";
+  errorMessage.hidden = true;
+  content.appendChild(errorMessage);
+
+  details.append(summary, content);
+  filtersContainer.appendChild(details);
+
+  const list = document.createElement("ul");
+  list.className = "spot-history__list";
+
+  const pagination = document.createElement("nav");
+  pagination.className = "spot-pagination";
+  pagination.setAttribute("aria-label", "Pagination des cueillettes");
+
+  historySection.append(historyHeading, filtersContainer, list, pagination);
+
+  const state = {
+    from: "",
+    to: "",
+    species: "",
+    page: 1,
+  };
+
+  const applyFilters = () => {
+    let filtered = [...pickings];
+    if (state.from) {
+      filtered = filtered.filter(
+        (item) => new Date(item.date) >= new Date(state.from),
+      );
+    }
+    if (state.to) {
+      filtered = filtered.filter(
+        (item) => new Date(item.date) <= new Date(state.to),
+      );
+    }
+    if (state.species) {
+      filtered = filtered.filter((item) =>
+        item.species.some((species) => species.name === state.species),
+      );
+    }
+    return filtered.sort((a, b) => new Date(b.date) - new Date(a.date));
+  };
+
+  const renderPagination = (totalPages) => {
+    pagination.innerHTML = "";
+    if (totalPages <= 1) {
+      return;
+    }
+
+    const addButton = (label, page, disabled = false, ariaLabel) => {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "spot-pagination__button";
+      btn.textContent = label;
+      if (ariaLabel) {
+        btn.setAttribute("aria-label", ariaLabel);
+      }
+      if (disabled) {
+        btn.disabled = true;
+      } else {
+        btn.addEventListener("click", () => {
+          state.page = page;
+          render();
+        });
+      }
+      if (page === state.page && !disabled && label !== "‹" && label !== "›") {
+        btn.setAttribute("aria-current", "page");
+      }
+      pagination.appendChild(btn);
+    };
+
+    addButton(
+      "‹",
+      Math.max(1, state.page - 1),
+      state.page === 1,
+      "Page précédente",
+    );
+
+    for (let page = 1; page <= totalPages; page += 1) {
+      addButton(String(page), page);
+    }
+
+    addButton(
+      "›",
+      Math.min(totalPages, state.page + 1),
+      state.page === totalPages,
+      "Page suivante",
+    );
+  };
+
+  const renderList = (items) => {
+    list.innerHTML = "";
+    if (items.length === 0) {
+      const empty = document.createElement("li");
+      empty.className = "spot-history__item spot-history__item--empty";
+      empty.textContent = "Aucune cueillette ne correspond à ces filtres.";
+      list.appendChild(empty);
+      pagination.innerHTML = "";
+      return;
+    }
+
+    const start = (state.page - 1) * ITEMS_PER_PAGE;
+    const paginated = items.slice(start, start + ITEMS_PER_PAGE);
+    paginated.forEach((item) => {
+      list.appendChild(createHistoryItem(item, formatNumber, showToast));
+    });
+
+    renderPagination(Math.ceil(items.length / ITEMS_PER_PAGE));
+  };
+
+  const render = () => {
+    const filtered = applyFilters();
+    const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
+    if (state.page > totalPages) {
+      state.page = totalPages;
+    }
+    renderList(filtered);
+  };
+
+  const validateDates = () => {
+    errorMessage.hidden = true;
+    errorMessage.textContent = "";
+    if (state.from && state.to && new Date(state.from) > new Date(state.to)) {
+      errorMessage.hidden = false;
+      errorMessage.textContent =
+        "La date de début doit être antérieure à la date de fin.";
+      return false;
+    }
+    return true;
+  };
+
+  const updateState = (key, value) => {
+    state[key] = value;
+    state.page = 1;
+    if (validateDates()) {
+      render();
+    }
+  };
+
+  fromInput.addEventListener("change", (event) => {
+    updateState("from", event.target.value || "");
+  });
+
+  toInput.addEventListener("change", (event) => {
+    updateState("to", event.target.value || "");
+  });
+
+  speciesSelect.addEventListener("change", (event) => {
+    updateState("species", event.target.value || "");
+  });
+
+  viewAll.addEventListener("click", () => {
+    historySection.scrollIntoView({ behavior: "smooth" });
+    historySection.focus();
+  });
+
+  render();
+
+  return { lastSection, historySection };
+}

--- a/src/js/spot-detail/components/rating.js
+++ b/src/js/spot-detail/components/rating.js
@@ -1,0 +1,176 @@
+const STAR_PATH =
+  "M12 2.248l2.92 5.912 6.528.948-4.724 4.604 1.116 6.508L12 17.9l-5.84 3.12 1.116-6.508-4.724-4.604 6.528-.948z";
+
+function createStarSvg(fillRatio) {
+  const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("focusable", "false");
+  svg.setAttribute("aria-hidden", "true");
+
+  const star = document.createElementNS("http://www.w3.org/2000/svg", "path");
+  star.setAttribute("d", STAR_PATH);
+  star.setAttribute("stroke-width", "1.5");
+  star.setAttribute("stroke-linejoin", "round");
+  star.setAttribute("stroke", "var(--color-primary)");
+  star.setAttribute("fill", "none");
+
+  if (fillRatio >= 1) {
+    star.setAttribute("fill", "var(--color-primary)");
+  } else if (fillRatio > 0) {
+    const gradientId = `spot-star-${Math.random().toString(36).slice(2)}`;
+    const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");
+    const linear = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "linearGradient",
+    );
+    linear.setAttribute("id", gradientId);
+    linear.setAttribute("x1", "0%");
+    linear.setAttribute("x2", "100%");
+    linear.setAttribute("y1", "0%");
+    linear.setAttribute("y2", "0%");
+
+    const stopFilled = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "stop",
+    );
+    stopFilled.setAttribute("offset", `${fillRatio * 100}%`);
+    stopFilled.setAttribute("stop-color", "var(--color-primary)");
+
+    const stopEmpty = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "stop",
+    );
+    stopEmpty.setAttribute("offset", `${fillRatio * 100}%`);
+    stopEmpty.setAttribute("stop-color", "transparent");
+
+    const stopEmptyEnd = document.createElementNS(
+      "http://www.w3.org/2000/svg",
+      "stop",
+    );
+    stopEmptyEnd.setAttribute("offset", "100%");
+    stopEmptyEnd.setAttribute("stop-color", "transparent");
+
+    linear.append(stopFilled, stopEmpty, stopEmptyEnd);
+    defs.append(linear);
+    svg.appendChild(defs);
+    star.setAttribute("fill", `url(#${gradientId})`);
+  }
+
+  svg.appendChild(star);
+  return svg;
+}
+
+export function createRatingDisplay(value, { max = 5, size = "default" } = {}) {
+  const safeValue = Math.max(0, Math.min(value ?? 0, max));
+  const wrapper = document.createElement("div");
+  wrapper.className = "spot-rating-display";
+  wrapper.setAttribute("role", "img");
+  wrapper.setAttribute(
+    "aria-label",
+    `Note : ${safeValue.toLocaleString("fr-FR", { maximumFractionDigits: 1 })} sur ${max}`,
+  );
+
+  for (let index = 0; index < max; index += 1) {
+    const ratio = Math.max(0, Math.min(1, safeValue - index));
+    const svg = createStarSvg(ratio);
+    if (size === "compact") {
+      svg.style.width = "0.9rem";
+      svg.style.height = "0.9rem";
+    }
+    wrapper.appendChild(svg);
+  }
+
+  return wrapper;
+}
+
+export function createRatingInput({
+  name,
+  value = 0,
+  max = 5,
+  legend = "Note",
+  description,
+  onChange,
+}) {
+  const fieldset = document.createElement("fieldset");
+  fieldset.className = "spot-note__group";
+
+  const legendElement = document.createElement("legend");
+  legendElement.textContent = legend;
+  fieldset.appendChild(legendElement);
+
+  const descriptionId = description
+    ? `spot-note-desc-${Math.random().toString(36).slice(2)}`
+    : undefined;
+
+  if (description) {
+    const desc = document.createElement("p");
+    desc.id = descriptionId;
+    desc.className = "spot-note__description";
+    desc.textContent = description;
+    fieldset.appendChild(desc);
+  }
+
+  const ratingContainer = document.createElement("div");
+  ratingContainer.className = "spot-rating-input";
+  ratingContainer.setAttribute("role", "radiogroup");
+  ratingContainer.setAttribute("aria-label", legend);
+  if (descriptionId) {
+    ratingContainer.setAttribute("aria-describedby", descriptionId);
+  }
+
+  const tooltip = document.createElement("div");
+  tooltip.className = "spot-rating-tooltip";
+  tooltip.setAttribute("aria-hidden", "true");
+  tooltip.textContent = `${value.toLocaleString("fr-FR", { maximumFractionDigits: 1 })}/${max}`;
+
+  let currentValue = value;
+
+  const updateTooltip = (newValue) => {
+    tooltip.textContent = `${newValue.toLocaleString("fr-FR", { maximumFractionDigits: 1 })}/${max}`;
+  };
+
+  const handleChange = (newValue) => {
+    currentValue = newValue;
+    updateTooltip(currentValue);
+    if (typeof onChange === "function") {
+      onChange(currentValue);
+    }
+  };
+
+  for (let index = 1; index <= max; index += 1) {
+    const id = `${name}-${index}`;
+    const input = document.createElement("input");
+    input.type = "radio";
+    input.name = name;
+    input.id = id;
+    input.value = String(index);
+    if (index === Math.round(value)) {
+      input.checked = true;
+    }
+
+    const label = document.createElement("label");
+    label.setAttribute("for", id);
+    label.appendChild(createStarSvg(index <= value ? 1 : 0));
+
+    input.addEventListener("change", () => {
+      handleChange(index);
+      ratingContainer
+        .querySelectorAll("label svg")
+        .forEach((svgElement, idx) => {
+          const fillRatio = idx + 1 <= index ? 1 : 0;
+          const newSvg = createStarSvg(fillRatio);
+          svgElement.replaceWith(newSvg);
+        });
+    });
+
+    label.addEventListener("mouseenter", () => updateTooltip(index));
+    label.addEventListener("focus", () => updateTooltip(index));
+    label.addEventListener("mouseleave", () => updateTooltip(currentValue));
+    label.addEventListener("blur", () => updateTooltip(currentValue));
+
+    ratingContainer.append(input, label);
+  }
+
+  fieldset.append(ratingContainer, tooltip);
+  return { element: fieldset, getValue: () => currentValue };
+}

--- a/src/js/spot-detail/components/spot-info.js
+++ b/src/js/spot-detail/components/spot-info.js
@@ -1,0 +1,76 @@
+const PRECISION_CONFIG = {
+  exact: { decimals: 5, label: "précision exacte" },
+  approx_100m: { decimals: 3, label: "≈100 m" },
+  approx_500m: { decimals: 2, label: "≈500 m" },
+  approx_1km: { decimals: 1, label: "≈1 km" },
+};
+
+function formatCoordinate(value, decimals) {
+  return Number.parseFloat(value).toFixed(decimals);
+}
+
+function getPrecisionLabel(precision) {
+  return PRECISION_CONFIG[precision]?.label || "précision estimée";
+}
+
+function getPrecisionDecimals(precision) {
+  return PRECISION_CONFIG[precision]?.decimals ?? 3;
+}
+
+export function createSpotInfoSection(spot, formatNumber) {
+  const section = document.createElement("section");
+  section.className = "spot-section spot-section--info";
+  section.setAttribute("aria-labelledby", "spot-info");
+
+  const heading = document.createElement("h2");
+  heading.id = "spot-info";
+  heading.textContent = "Infos du coin";
+  section.appendChild(heading);
+
+  const summary = document.createElement("div");
+  summary.className = "spot-info__summary";
+
+  const location = document.createElement("p");
+  location.className = "spot-info__location";
+  location.textContent = `${spot.city} – ${spot.address}`;
+  summary.appendChild(location);
+
+  const decimals = getPrecisionDecimals(spot.precision);
+  const coordsText = `${formatCoordinate(spot.coordinates.lat, decimals)}°, ${formatCoordinate(
+    spot.coordinates.lng,
+    decimals,
+  )}°`;
+
+  const coords = document.createElement("p");
+  coords.className = "spot-info__coords";
+  coords.textContent = `Coordonnées ${getPrecisionLabel(spot.precision)} : ${coordsText}`;
+  summary.appendChild(coords);
+
+  section.appendChild(summary);
+
+  const metaList = document.createElement("dl");
+  metaList.className = "spot-info__meta";
+
+  const createdWrapper = document.createElement("div");
+  const createdTitle = document.createElement("dt");
+  createdTitle.textContent = "Créé le";
+  const createdValue = document.createElement("dd");
+  createdValue.textContent = new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(new Date(spot.createdAt));
+  createdWrapper.append(createdTitle, createdValue);
+
+  const pickingsWrapper = document.createElement("div");
+  const pickingsTitle = document.createElement("dt");
+  pickingsTitle.textContent = "Nombre de cueillettes";
+  const pickingsValue = document.createElement("dd");
+  pickingsValue.textContent = formatNumber(spot.pickingsCount);
+  pickingsWrapper.append(pickingsTitle, pickingsValue);
+
+  metaList.append(createdWrapper, pickingsWrapper);
+  section.appendChild(metaList);
+
+  return section;
+}

--- a/src/js/spot-detail/components/spot-map.js
+++ b/src/js/spot-detail/components/spot-map.js
@@ -1,0 +1,129 @@
+const MAP_DELTA = 0.02;
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function formatCoordinate(value) {
+  return clamp(value, -180, 180).toFixed(6);
+}
+
+function buildMapUrl({ lat, lng }) {
+  const latClamped = clamp(lat, -90, 90);
+  const lngClamped = clamp(lng, -180, 180);
+  const delta = MAP_DELTA;
+
+  const left = formatCoordinate(lngClamped - delta);
+  const right = formatCoordinate(lngClamped + delta);
+  const bottom = formatCoordinate(latClamped - delta);
+  const top = formatCoordinate(latClamped + delta);
+
+  const bbox = `${left}%2C${bottom}%2C${right}%2C${top}`;
+  const markerLat = formatCoordinate(latClamped);
+  const markerLng = formatCoordinate(lngClamped);
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=mapnik&marker=${markerLat}%2C${markerLng}`;
+}
+
+const PRECISION_LABELS = {
+  exact: "coordonnées exactes",
+  approx_100m: "≈100 m",
+  approx_500m: "≈500 m",
+  approx_1km: "≈1 km",
+};
+
+function getPrecisionText(precision, city) {
+  const label = PRECISION_LABELS[precision] || "zone indiquée";
+  return `${city} (${label})`;
+}
+
+export function createSpotMapSection(spot) {
+  const section = document.createElement("section");
+  section.className = "spot-section spot-section--map";
+  section.setAttribute("aria-labelledby", "spot-map");
+
+  const heading = document.createElement("h2");
+  heading.id = "spot-map";
+  heading.textContent = "Carte";
+
+  const description = document.createElement("p");
+  description.textContent = `Carte centrée sur ${getPrecisionText(spot.precision, spot.city)}.`;
+
+  const frameWrapper = document.createElement("div");
+  frameWrapper.className = "spot-map__frame";
+
+  const iframe = document.createElement("iframe");
+  iframe.loading = "lazy";
+  iframe.title = `Carte de ${spot.name}`;
+  iframe.src = buildMapUrl(spot.coordinates);
+  frameWrapper.appendChild(iframe);
+
+  const actions = document.createElement("div");
+  actions.className = "spot-map__actions";
+
+  const enlargeButton = document.createElement("button");
+  enlargeButton.type = "button";
+  enlargeButton.className = "spot-button spot-button--primary";
+  enlargeButton.textContent = "Agrandir";
+  enlargeButton.addEventListener("click", () => {
+    openModal();
+  });
+
+  actions.appendChild(enlargeButton);
+
+  section.append(heading, description, frameWrapper, actions);
+
+  const modal = document.createElement("dialog");
+  modal.className = "spot-modal";
+  const modalContent = document.createElement("div");
+  modalContent.className = "spot-modal__content";
+  modalContent.innerHTML = `
+    <div class="spot-modal__header">
+      <h2>Carte agrandie</h2>
+      <button type="button" class="spot-button spot-button--secondary" aria-label="Fermer la carte">Fermer</button>
+    </div>
+    <iframe title="Carte agrandie" style="width:100%;height:480px;border:0" loading="lazy"></iframe>
+  `;
+
+  const closeButton = modalContent.querySelector("button");
+  const modalIframe = modalContent.querySelector("iframe");
+  modalIframe.src = iframe.src;
+
+  const closeModal = () => {
+    modal.close();
+  };
+
+  closeButton.addEventListener("click", closeModal);
+  modal.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    closeModal();
+  });
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) {
+      closeModal();
+    }
+  });
+
+  modal.addEventListener("close", () => {
+    enlargeButton.focus();
+  });
+
+  modal.appendChild(modalContent);
+  document.body.appendChild(modal);
+
+  const openModal = () => {
+    modalIframe.src = iframe.src;
+    modal.showModal();
+    closeButton.focus();
+  };
+
+  return section;
+}
+
+export function buildMapPageUrl({ lat, lng, zoom = 14 }) {
+  const params = new URLSearchParams({
+    lat: clamp(lat, -90, 90).toFixed(4),
+    lng: clamp(lng, -180, 180).toFixed(4),
+    zoom: String(zoom),
+  });
+  return `map.html?${params.toString()}`;
+}

--- a/src/js/spot-detail/spot-detail-page.js
+++ b/src/js/spot-detail/spot-detail-page.js
@@ -1,0 +1,397 @@
+import { createActivityHeader } from "./components/activity-header.js";
+import { createSpotInfoSection } from "./components/spot-info.js";
+import {
+  createSpotMapSection,
+  buildMapPageUrl,
+} from "./components/spot-map.js";
+import { createPickingsSections } from "./components/pickings-list.js";
+import { createPhotosGallery } from "./components/photos-gallery.js";
+import { createRatingInput } from "./components/rating.js";
+import { createActivityChartSection } from "./components/activity-chart.js";
+
+const root = document.querySelector("[data-spot-detail-root]");
+const toastContainer = document.querySelector("[data-spot-toast-container]");
+
+if (!root || !toastContainer) {
+  throw new Error("Conteneur de page de détail introuvable.");
+}
+
+const skeletonTemplate = root.innerHTML;
+
+const numberFormatter = new Intl.NumberFormat("fr-FR", {
+  maximumFractionDigits: 1,
+});
+
+const longDateFormatter = new Intl.DateTimeFormat("fr-FR", {
+  day: "numeric",
+  month: "long",
+  year: "numeric",
+});
+
+function formatNumber(value) {
+  return numberFormatter.format(value ?? 0);
+}
+
+function formatFullDate(date) {
+  return longDateFormatter.format(new Date(date));
+}
+
+function removeToast(toast) {
+  if (toast && toast.parentElement) {
+    toast.parentElement.removeChild(toast);
+  }
+}
+
+function showToast(message, { actionLabel, onAction, duration } = {}) {
+  const toast = document.createElement("div");
+  toast.className = "spot-toast";
+  toast.setAttribute("role", "alert");
+
+  const content = document.createElement("p");
+  content.textContent = message;
+  toast.appendChild(content);
+
+  const actions = document.createElement("div");
+  actions.className = "spot-toast__actions";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "spot-button spot-button--secondary";
+  closeButton.textContent = "Fermer";
+  closeButton.addEventListener("click", () => removeToast(toast));
+
+  if (actionLabel && typeof onAction === "function") {
+    const actionButton = document.createElement("button");
+    actionButton.type = "button";
+    actionButton.className = "spot-button spot-button--primary";
+    actionButton.textContent = actionLabel;
+    actionButton.addEventListener("click", () => {
+      onAction();
+      removeToast(toast);
+    });
+    actions.appendChild(actionButton);
+  }
+
+  actions.appendChild(closeButton);
+  toast.appendChild(actions);
+  toastContainer.appendChild(toast);
+
+  if (!actionLabel) {
+    const timeout = duration ?? 5000;
+    window.setTimeout(() => removeToast(toast), timeout);
+  }
+
+  return toast;
+}
+
+function showSkeleton() {
+  root.innerHTML = skeletonTemplate;
+  root.setAttribute("aria-busy", "true");
+}
+
+function createBreadcrumb(spotName) {
+  const nav = document.createElement("nav");
+  nav.className = "spot-detail__breadcrumb";
+  nav.setAttribute("aria-label", "Fil d’Ariane");
+
+  const list = document.createElement("ol");
+
+  const addItem = (content, options = {}) => {
+    const item = document.createElement("li");
+    if (options.current) {
+      item.setAttribute("aria-current", "page");
+    }
+    if (options.href) {
+      const link = document.createElement("a");
+      link.href = options.href;
+      link.textContent = content;
+      item.appendChild(link);
+    } else {
+      item.textContent = content;
+    }
+    list.appendChild(item);
+  };
+
+  addItem("Accueil", { href: "index.html" });
+  addItem("›", { ariaHidden: true });
+  list.lastElementChild.setAttribute("aria-hidden", "true");
+  addItem("Carte", { href: "map.html" });
+  addItem("›", { ariaHidden: true });
+  list.lastElementChild.setAttribute("aria-hidden", "true");
+  addItem(spotName, { current: true });
+
+  nav.appendChild(list);
+  return nav;
+}
+
+function createDrawer() {
+  const dialog = document.createElement("dialog");
+  dialog.className = "spot-drawer";
+  dialog.setAttribute("aria-labelledby", "spot-drawer-title");
+  dialog.innerHTML = `
+    <div class="spot-drawer__content">
+      <div class="spot-drawer__header">
+        <h2 id="spot-drawer-title">Ajouter une cueillette</h2>
+        <button type="button" class="spot-button spot-button--secondary" aria-label="Fermer le panneau">Fermer</button>
+      </div>
+      <div class="spot-drawer__body">
+        <div class="spot-drawer__placeholder">
+          <p>Un formulaire simplifié apparaîtra ici pour saisir une nouvelle cueillette.</p>
+          <p>Cette démonstration n’enregistre pas encore les données.</p>
+        </div>
+      </div>
+    </div>
+  `;
+
+  let returnFocusTo = null;
+  const closeButton = dialog.querySelector(
+    'button[aria-label="Fermer le panneau"]',
+  );
+
+  const close = () => {
+    dialog.close();
+  };
+
+  closeButton.addEventListener("click", close);
+  dialog.addEventListener("cancel", (event) => {
+    event.preventDefault();
+    close();
+  });
+  dialog.addEventListener("click", (event) => {
+    if (event.target === dialog) {
+      close();
+    }
+  });
+  dialog.addEventListener("close", () => {
+    if (returnFocusTo) {
+      returnFocusTo.focus();
+    }
+  });
+
+  document.body.appendChild(dialog);
+
+  return {
+    open(trigger) {
+      returnFocusTo = trigger || null;
+      dialog.showModal();
+      closeButton.focus();
+    },
+  };
+}
+
+function createActivitySummary(pickings, onAddPicking) {
+  const section = document.createElement("section");
+  section.className = "spot-section spot-section--activity";
+  section.setAttribute("aria-labelledby", "spot-activity");
+
+  const heading = document.createElement("h2");
+  heading.id = "spot-activity";
+  heading.textContent = "Activité";
+
+  section.appendChild(heading);
+
+  const addButton = document.createElement("button");
+  addButton.type = "button";
+  addButton.className = "spot-button spot-button--primary";
+  addButton.textContent = "Ajouter une cueillette";
+  addButton.addEventListener("click", (event) => {
+    if (typeof onAddPicking === "function") {
+      onAddPicking(event.currentTarget);
+    }
+  });
+
+  if (!pickings.length) {
+    const empty = document.createElement("div");
+    empty.className = "spot-empty-state";
+    const text = document.createElement("p");
+    text.textContent = "Aucune cueillette enregistrée.";
+    empty.append(text, addButton);
+    section.appendChild(empty);
+    return section;
+  }
+
+  const summary = document.createElement("div");
+  summary.className = "spot-activity-summary";
+
+  const uniqueSpecies = new Set();
+  let totalWeight = 0;
+  pickings.forEach((picking) => {
+    totalWeight += picking.totalWeightKg ?? 0;
+    picking.species.forEach((species) => uniqueSpecies.add(species.name));
+  });
+
+  const createStat = (label, value) => {
+    const item = document.createElement("div");
+    item.className = "spot-activity-summary__stat";
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    dd.textContent = value;
+    item.append(dt, dd);
+    return item;
+  };
+
+  const statsList = document.createElement("dl");
+  statsList.className = "spot-activity-summary__stats";
+  statsList.append(
+    createStat("Espèces observées", formatNumber(uniqueSpecies.size)),
+    createStat("Poids cumulé", `${formatNumber(totalWeight)} kg`),
+    createStat("Cueillettes", formatNumber(pickings.length)),
+  );
+
+  const latest = pickings.reduce(
+    (recent, current) =>
+      new Date(current.date) > new Date(recent.date) ? current : recent,
+    pickings[0],
+  );
+
+  const update = document.createElement("p");
+  update.textContent = `Dernière cueillette le ${formatFullDate(latest.date)} (${formatNumber(
+    latest.totalWeightKg,
+  )} kg).`;
+
+  const actions = document.createElement("div");
+  actions.className = "spot-activity-summary__actions";
+  actions.appendChild(addButton);
+
+  summary.append(statsList, update, actions);
+  section.appendChild(summary);
+  return section;
+}
+
+const drawer = createDrawer();
+
+function renderSpotDetail(data) {
+  root.innerHTML = "";
+  root.setAttribute("aria-busy", "false");
+
+  const breadcrumb = createBreadcrumb(data.spot.name);
+  root.appendChild(breadcrumb);
+
+  const photosGallery = createPhotosGallery({
+    photos: data.photos,
+    showToast,
+  });
+
+  const mapUrl = buildMapPageUrl({
+    lat: data.spot.coordinates.lat,
+    lng: data.spot.coordinates.lng,
+    zoom: 14,
+  });
+
+  const header = createActivityHeader({
+    spot: data.spot,
+    mapUrl,
+    onAddPicking: (trigger) => drawer.open(trigger),
+    onAddPhoto: () => photosGallery.triggerAdd(),
+    showToast,
+  });
+
+  root.appendChild(header.element);
+
+  const sections = document.createElement("div");
+  sections.className = "spot-detail__sections";
+
+  sections.appendChild(createSpotInfoSection(data.spot, formatNumber));
+  sections.appendChild(createSpotMapSection(data.spot));
+
+  const lastPicking = data.spot.lastPicking || data.pickings[0];
+  const pickingsSections = createPickingsSections({
+    lastPicking,
+    pickings: data.pickings,
+    formatNumber,
+    onAddPicking: (trigger) => drawer.open(trigger),
+    showToast,
+  });
+
+  sections.append(
+    pickingsSections.lastSection,
+    pickingsSections.historySection,
+  );
+  sections.appendChild(photosGallery.element);
+
+  const noteSection = document.createElement("section");
+  noteSection.className = "spot-section spot-section--note";
+  noteSection.setAttribute("aria-labelledby", "spot-note");
+
+  const noteHeading = document.createElement("h2");
+  noteHeading.id = "spot-note";
+  noteHeading.textContent = "Note du coin";
+
+  const averageRating = data.pickings.length
+    ? data.pickings.reduce((sum, item) => sum + (item.rating ?? 0), 0) /
+      data.pickings.length
+    : 0;
+
+  const ratingComponent = createRatingInput({
+    name: "spot-rating",
+    value: Math.round(averageRating || 0),
+    legend: "Note",
+    description: "Attribuez une note de 1 à 5 étoiles pour ce coin.",
+    onChange: (value) => {
+      showToast(`Votre note ${value}/5 est prise en compte (démonstration).`);
+    },
+  });
+
+  const noteInfo = document.createElement("p");
+  noteInfo.className = "spot-note__info";
+  noteInfo.textContent = data.pickings.length
+    ? `Note moyenne actuelle : ${formatNumber(averageRating)} / 5 (basée sur ${formatNumber(
+        data.pickings.length,
+      )} cueillettes).`
+    : "Ce coin n’a pas encore reçu de note.";
+
+  noteSection.append(noteHeading, ratingComponent.element, noteInfo);
+
+  sections.appendChild(noteSection);
+
+  sections.appendChild(
+    createActivityChartSection(data.spot.activitySeries, formatNumber),
+  );
+  sections.appendChild(
+    createActivitySummary(data.pickings, (trigger) => drawer.open(trigger)),
+  );
+
+  root.appendChild(sections);
+}
+
+async function loadData() {
+  showSkeleton();
+
+  try {
+    const response = await fetch("data/spot-detail.json", {
+      headers: {
+        "Cache-Control": "no-cache",
+      },
+    });
+    if (!response.ok) {
+      throw new Error("Réponse invalide du serveur.");
+    }
+    const data = await response.json();
+    renderSpotDetail(data);
+  } catch (error) {
+    root.innerHTML = "";
+    root.setAttribute("aria-busy", "false");
+    const fallback = document.createElement("section");
+    fallback.className = "spot-section";
+    const heading = document.createElement("h2");
+    heading.textContent = "Chargement impossible";
+    const message = document.createElement("p");
+    message.textContent =
+      "Impossible de récupérer les informations de ce coin pour le moment.";
+    fallback.append(heading, message);
+    root.appendChild(fallback);
+
+    showToast("Échec du chargement des données.", {
+      actionLabel: "Réessayer",
+      onAction: () => {
+        loadData();
+      },
+      duration: 8000,
+    });
+
+    console.error("Erreur de chargement du détail du coin", error);
+  }
+}
+
+loadData();


### PR DESCRIPTION
## Summary
- add the new coin detail page and supporting responsive styles
- implement modular JS components to render spot info, pickings, gallery, rating and activity chart from JSON data
- add mock spot dataset and document how to maintain it

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2b7490c7c8329a5411120000f5f21