### PR TITLE
Ensure map permissions check handles missing API

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -139,7 +139,7 @@ export function initializeMapPage() {
     }
 
     if (
-      "permissions" in navigator &&
+      navigator.permissions &&
       typeof navigator.permissions.query === "function"
     ) {
       try {


### PR DESCRIPTION
## Summary
- guard the geolocation permissions check so navigator.permissions is truthy before querying

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d2c59d292883299a6b5f9ba4398689